### PR TITLE
[TASK-07] JWT authentication and ownership validation on payment endpoints

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -87,7 +87,7 @@ func registerModules(api *gin.RouterGroup, authMiddleware gin.HandlerFunc, cfg c
 	stripeClient := stripeplatform.NewClient(cfg.StripeSecretKey)
 	transactionRepo := transactionsModule.NewPostgresRepository(pool)
 	transactionSvc := transactionsModule.NewService(transactionRepo, stripeClient)
-	transactionsModule.NewHandler(transactionRepo, transactionSvc).RegisterRoutes(api)
+	transactionsModule.NewHandler(transactionRepo, transactionSvc).RegisterRoutes(api, authMiddleware)
 
 	// Messages
 	messagesModule.NewHandler(messagesModule.NewPostgresRepository(pool)).RegisterRoutes(api)

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -85,9 +85,15 @@ func (h *Handler) listByBorrower(c *gin.Context) {
 }
 
 func (h *Handler) createTransaction(c *gin.Context) {
+	userID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	borrowerID := userID.(string)
+
 	var body struct {
 		ListingID          string `json:"listing_id"`
-		BorrowerID         string `json:"borrower_id"`
 		PaymentMethodID    string `json:"payment_method_id"`
 		DepositAmountCents int64  `json:"deposit_amount_cents"`
 	}
@@ -95,13 +101,6 @@ func (h *Handler) createTransaction(c *gin.Context) {
 		slog.Error("failed to parse create transaction body", "error", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
-	}
-
-	// TODO: when JWT is implemented, borrower_id must be extracted from the token,
-	// not from the body or the X-User-ID header.
-	borrowerID := c.GetHeader("X-User-ID")
-	if borrowerID == "" {
-		borrowerID = body.BorrowerID
 	}
 
 	t, err := h.service.AgreeDeal(c.Request.Context(), body.ListingID, borrowerID, body.PaymentMethodID, body.DepositAmountCents)

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -20,14 +20,17 @@ func NewHandler(repo Repository, service *Service) *Handler {
 }
 
 // RegisterRoutes attaches the transactions routes to a Gin router group.
-func (h *Handler) RegisterRoutes(rg *gin.RouterGroup) {
+func (h *Handler) RegisterRoutes(rg *gin.RouterGroup, authMiddleware gin.HandlerFunc) {
 	rg.GET("/transactions", h.listTransactions)
 	rg.GET("/transactions/:id", h.getTransaction)
 	rg.GET("/listings/:id/transactions", h.listByListing)
 	rg.GET("/users/:id/transactions", h.listByBorrower)
-	rg.POST("/transactions", h.createTransaction)
-	rg.POST("/transactions/:id/handover", h.handoverTransaction)
-	rg.POST("/transactions/:id/return", h.returnTransaction)
+
+	protected := rg.Group("/")
+	protected.Use(authMiddleware)
+	protected.POST("/transactions", h.createTransaction)
+	protected.POST("/transactions/:id/handover", h.handoverTransaction)
+	protected.POST("/transactions/:id/return", h.returnTransaction)
 }
 
 func (h *Handler) listTransactions(c *gin.Context) {

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -116,8 +116,20 @@ func (h *Handler) createTransaction(c *gin.Context) {
 func (h *Handler) handoverTransaction(c *gin.Context) {
 	id := c.Param("id")
 
-	// TODO: when JWT is implemented, validate that the caller is the owner of the listing.
-	_ = c.GetHeader("X-User-ID")
+	callerID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+		return
+	}
+	if ownerID != callerID.(string) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
 
 	if err := h.service.Handover(c.Request.Context(), id); err != nil {
 		slog.Error("failed to handover transaction", "id", id, "error", err)
@@ -139,8 +151,20 @@ func (h *Handler) handoverTransaction(c *gin.Context) {
 func (h *Handler) returnTransaction(c *gin.Context) {
 	id := c.Param("id")
 
-	// TODO: when JWT is implemented, validate that the caller is the owner of the listing.
-	_ = c.GetHeader("X-User-ID")
+	callerID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+		return
+	}
+	if ownerID != callerID.(string) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
 
 	var body struct {
 		DepositAmountCents int64 `json:"deposit_amount_cents"`

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -142,6 +142,7 @@ func makeToken(userID string) string {
 func setupRouter(repo transactions.Repository) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	r.Use(gin.Recovery())
 	h := transactions.NewHandler(repo, nil)
 	api := r.Group("/api")
 	h.RegisterRoutes(api, middleware.RequireAuth(testJWTSecret))

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -1,23 +1,28 @@
 package transactions_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/isw2-unileon/neighborlink/backend/internal/platform/middleware"
 	"github.com/isw2-unileon/neighborlink/backend/internal/transactions"
 	"github.com/stretchr/testify/assert"
 )
 
 type fakeRepository struct {
-	transactions []transactions.Transaction
-	err          error
+	transactions          []transactions.Transaction
+	err                   error
+	ownerByTransactionID  map[string]string
 }
 
 func (f *fakeRepository) FindAll(ctx context.Context) ([]transactions.Transaction, error) {
@@ -60,6 +65,18 @@ func (f *fakeRepository) FindByBorrower(ctx context.Context, borrowerID string) 
 		}
 	}
 	return result, nil
+}
+
+func (f *fakeRepository) FindListingOwnerByTransactionID(ctx context.Context, id string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	if f.ownerByTransactionID != nil {
+		if ownerID, ok := f.ownerByTransactionID[id]; ok {
+			return ownerID, nil
+		}
+	}
+	return "", fmt.Errorf("transaction %s not found", id)
 }
 
 func (f *fakeRepository) Create(ctx context.Context, t transactions.Transaction) (*transactions.Transaction, error) {
@@ -110,12 +127,24 @@ func (f *fakeRepository) UpdateStatus(ctx context.Context, id string, status str
 	return fmt.Errorf("transaction %s not found", id)
 }
 
+const testJWTSecret = "test-secret"
+
+func makeToken(userID string) string {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	t, _ := token.SignedString([]byte(testJWTSecret))
+	return "Bearer " + t
+}
+
 func setupRouter(repo transactions.Repository) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h := transactions.NewHandler(repo, nil)
 	api := r.Group("/api")
-	h.RegisterRoutes(api)
+	h.RegisterRoutes(api, middleware.RequireAuth(testJWTSecret))
 	return r
 }
 
@@ -253,4 +282,104 @@ func TestListByBorrower(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateTransaction_RequiresAuth(t *testing.T) {
+	router := setupRouter(&fakeRepository{})
+
+	body := `{"listing_id":"l-1","payment_method_id":"pm_test","deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestHandoverTransaction_RequiresAuth(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/handover", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestHandoverTransaction_ForbidsNonOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/handover", nil)
+	req.Header.Set("Authorization", makeToken("other-user"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestHandoverTransaction_AllowsOwner(t *testing.T) {
+	// service is nil so Handover will panic — use a fake service via nil check,
+	// but here we just verify the auth layer passes through (service call will error).
+	// We can't test the full success path without a real service, but 500 (not 401/403)
+	// confirms the auth check passed.
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/handover", bytes.NewReader([]byte{}))
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
+func TestReturnTransaction_RequiresAuth(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/return", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestReturnTransaction_ForbidsNonOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/return", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("other-user"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestReturnTransaction_AllowsOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/return", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
 }

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -133,6 +133,19 @@ func (r *postgresRepository) UpdatePaymentIntent(ctx context.Context, id string,
 	return nil
 }
 
+func (r *postgresRepository) FindListingOwnerByTransactionID(ctx context.Context, transactionID string) (string, error) {
+	const q = `SELECT l.owner_id FROM transactions t JOIN listings l ON t.listing_id = l.id WHERE t.id = $1`
+	var ownerID string
+	err := r.pool.QueryRow(ctx, q, transactionID).Scan(&ownerID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("transaction %s not found", transactionID)
+	}
+	if err != nil {
+		return "", fmt.Errorf("transactions: find listing owner failed: %w", err)
+	}
+	return ownerID, nil
+}
+
 func (r *postgresRepository) UpdateStatus(ctx context.Context, id string, status string) error {
 	var err error
 	switch status {

--- a/backend/internal/transactions/repository.go
+++ b/backend/internal/transactions/repository.go
@@ -20,4 +20,8 @@ type Repository interface {
 	// UpdateStatus updates only the status field and the corresponding timestamp.
 	// validStatuses: handed_over (sets handover_at), returned (sets return_at), cancelled.
 	UpdateStatus(ctx context.Context, id string, status string) error
+
+	// FindListingOwnerByTransactionID returns the owner_id of the listing associated
+	// with the given transaction. Returns an error if the transaction does not exist.
+	FindListingOwnerByTransactionID(ctx context.Context, transactionID string) (string, error)
 }


### PR DESCRIPTION
Closes #34

## Summary

- Extract `borrower_id` from JWT (`sub` claim) in `POST /api/transactions` — removes the temporary `X-User-ID` header and `borrower_id` from the request body
- Validate that the caller is the listing owner in `POST /api/transactions/:id/handover` and `POST /api/transactions/:id/return` (403 if not owner, 401 if unauthenticated)
- Add `FindListingOwnerByTransactionID` to the transaction repository (JOIN with `listings` table) to resolve ownership without cross-module imports
- Add authorization tests: 401 without token, 403 for non-owner, pass-through for owner

## Test plan

- [ ] `go test ./backend/internal/transactions/... -v` — all tests pass
- [ ] `POST /api/transactions` without JWT returns 401
- [ ] `POST /api/transactions` with valid JWT creates the transaction using the token's `sub` as `borrower_id`
- [ ] `POST /api/transactions/:id/handover` with a JWT that is not the listing owner returns 403
- [ ] `POST /api/transactions/:id/handover` with the listing owner's JWT returns 200
- [ ] Same checks for `POST /api/transactions/:id/return`