### PR TITLE
[US-14] Fee structure — deposit + 2€ management fee

### DIFF
--- a/backend/internal/transactions/domain.go
+++ b/backend/internal/transactions/domain.go
@@ -15,6 +15,7 @@ type Transaction struct {
 	Status                string     `json:"status"`
 	StripePaymentIntentID string     `json:"stripe_payment_intent_id,omitempty"`
 	PaymentMethodID       string     `json:"payment_method_id,omitempty"`
+	TotalChargedCents     int64      `json:"total_charged_cents,omitempty"`
 	AgreedAt              *time.Time `json:"agreed_at"`
 	HandoverAt            *time.Time `json:"handover_at"`
 	ReturnAt              *time.Time `json:"return_at"`

--- a/backend/internal/transactions/domain.go
+++ b/backend/internal/transactions/domain.go
@@ -3,6 +3,9 @@ package transactions
 
 import "time"
 
+// PlatformFeeCents is the fixed management + insurance fee charged to the borrower on top of the deposit.
+const PlatformFeeCents int64 = 200
+
 // Transaction represents a loan agreement between an owner and a borrower.
 // Pure business data — zero external dependencies.
 type Transaction struct {

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -73,7 +73,7 @@ func (f *fakeRepository) Create(ctx context.Context, t transactions.Transaction)
 	return &created, nil
 }
 
-func (f *fakeRepository) UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string) error {
+func (f *fakeRepository) UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string, totalChargedCents int64) error {
 	if f.err != nil {
 		return f.err
 	}

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -21,7 +21,7 @@ func NewPostgresRepository(pool *pgxpool.Pool) Repository {
 
 func (r *postgresRepository) FindAll(ctx context.Context) ([]Transaction, error) {
 	rows, err := r.pool.Query(ctx, `
-		SELECT id, listing_id, borrower_id, status, agreed_at, handover_at, return_at
+		SELECT id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
 		FROM transactions
 	`)
 	if err != nil {
@@ -32,7 +32,7 @@ func (r *postgresRepository) FindAll(ctx context.Context) ([]Transaction, error)
 	transactions := make([]Transaction, 0)
 	for rows.Next() {
 		var t Transaction
-		if err := rows.Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.TotalChargedCents, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt); err != nil {
 			return nil, fmt.Errorf("transactions: scan failed: %w", err)
 		}
 		transactions = append(transactions, t)
@@ -47,10 +47,10 @@ func (r *postgresRepository) FindAll(ctx context.Context) ([]Transaction, error)
 func (r *postgresRepository) FindByID(ctx context.Context, id string) (*Transaction, error) {
 	var t Transaction
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, listing_id, borrower_id, status, agreed_at, handover_at, return_at
+		SELECT id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
 		FROM transactions
 		WHERE id = $1
-	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt)
+	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.TotalChargedCents, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -67,7 +67,7 @@ func (r *postgresRepository) scanRows(rows pgx.Rows) ([]Transaction, error) {
 	transactions := make([]Transaction, 0)
 	for rows.Next() {
 		var t Transaction
-		if err := rows.Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt); err != nil {
+		if err := rows.Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.TotalChargedCents, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt); err != nil {
 			return nil, fmt.Errorf("transactions: scan failed: %w", err)
 		}
 		transactions = append(transactions, t)
@@ -80,7 +80,7 @@ func (r *postgresRepository) scanRows(rows pgx.Rows) ([]Transaction, error) {
 
 func (r *postgresRepository) FindByListing(ctx context.Context, listingID string) ([]Transaction, error) {
 	rows, err := r.pool.Query(ctx, `
-        SELECT id, listing_id, borrower_id, status, agreed_at, handover_at, return_at
+        SELECT id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
         FROM transactions WHERE listing_id = $1
     `, listingID)
 	if err != nil {
@@ -92,7 +92,7 @@ func (r *postgresRepository) FindByListing(ctx context.Context, listingID string
 
 func (r *postgresRepository) FindByBorrower(ctx context.Context, borrowerID string) ([]Transaction, error) {
 	rows, err := r.pool.Query(ctx, `
-        SELECT id, listing_id, borrower_id, status, agreed_at, handover_at, return_at
+        SELECT id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
         FROM transactions WHERE borrower_id = $1
     `, borrowerID)
 	if err != nil {
@@ -107,10 +107,10 @@ func (r *postgresRepository) Create(ctx context.Context, t Transaction) (*Transa
 	err := r.pool.QueryRow(ctx, `
 		INSERT INTO transactions (listing_id, borrower_id, status)
 		VALUES ($1, $2, 'pending')
-		RETURNING id, listing_id, borrower_id, status, agreed_at, handover_at, return_at
+		RETURNING id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
 	`, t.ListingID, t.BorrowerID).Scan(
 		&created.ID, &created.ListingID, &created.BorrowerID, &created.Status,
-		&created.AgreedAt, &created.HandoverAt, &created.ReturnAt,
+		&created.TotalChargedCents, &created.AgreedAt, &created.HandoverAt, &created.ReturnAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("transactions: insert failed: %w", err)
@@ -118,15 +118,16 @@ func (r *postgresRepository) Create(ctx context.Context, t Transaction) (*Transa
 	return &created, nil
 }
 
-func (r *postgresRepository) UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string) error {
+func (r *postgresRepository) UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string, totalChargedCents int64) error {
 	_, err := r.pool.Exec(ctx, `
 		UPDATE transactions
 		SET stripe_payment_intent_id = $1,
 		    payment_method_id        = $2,
+		    total_charged_cents      = $3,
 		    status                   = 'agreed',
 		    agreed_at                = NOW()
-		WHERE id = $3
-	`, paymentIntentID, paymentMethodID, id)
+		WHERE id = $4
+	`, paymentIntentID, paymentMethodID, totalChargedCents, id)
 	if err != nil {
 		return fmt.Errorf("transactions: update payment intent failed: %w", err)
 	}

--- a/backend/internal/transactions/repository.go
+++ b/backend/internal/transactions/repository.go
@@ -13,9 +13,9 @@ type Repository interface {
 	// Create inserts a new transaction and returns it with the generated ID.
 	Create(ctx context.Context, t Transaction) (*Transaction, error)
 
-	// UpdatePaymentIntent stores the Stripe PaymentIntent ID and payment method ID
-	// on the transaction and sets its status to agreed.
-	UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string) error
+	// UpdatePaymentIntent stores the Stripe PaymentIntent ID, payment method ID, and total
+	// charged amount on the transaction and sets its status to agreed.
+	UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string, totalChargedCents int64) error
 
 	// UpdateStatus updates only the status field and the corresponding timestamp.
 	// validStatuses: handed_over (sets handover_at), returned (sets return_at), cancelled.

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -39,12 +39,13 @@ func (s *Service) AgreeDeal(ctx context.Context, listingID, borrowerID, paymentM
 		return nil, fmt.Errorf("service: authorize deposit: %w", err)
 	}
 
-	if err := s.repo.UpdatePaymentIntent(ctx, t.ID, paymentIntentID, paymentMethodID); err != nil {
+	if err := s.repo.UpdatePaymentIntent(ctx, t.ID, paymentIntentID, paymentMethodID, totalCents); err != nil {
 		return nil, fmt.Errorf("service: update payment intent: %w", err)
 	}
 
 	t.StripePaymentIntentID = paymentIntentID
 	t.PaymentMethodID = paymentMethodID
+	t.TotalChargedCents = totalCents
 	t.Status = "agreed"
 	return t, nil
 }

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -33,7 +33,8 @@ func (s *Service) AgreeDeal(ctx context.Context, listingID, borrowerID, paymentM
 		return nil, fmt.Errorf("service: create transaction: %w", err)
 	}
 
-	paymentIntentID, err := s.stripe.AuthorizeDeposit(depositAmountCents, "eur", paymentMethodID)
+	totalCents := depositAmountCents + PlatformFeeCents
+	paymentIntentID, err := s.stripe.AuthorizeDeposit(totalCents, "eur", paymentMethodID)
 	if err != nil {
 		return nil, fmt.Errorf("service: authorize deposit: %w", err)
 	}

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -3,19 +3,25 @@ package transactions
 import (
 	"context"
 	"fmt"
-
-	stripeclient "github.com/isw2-unileon/neighborlink/backend/internal/platform/stripe"
 )
+
+// stripeDepositor is the subset of stripe.Client used by the service.
+// Declared here so the service can be tested without a real Stripe key.
+type stripeDepositor interface {
+	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error)
+	CaptureDeposit(paymentIntentID string) error
+	ReleaseDeposit(paymentIntentID string, totalAmountCents int64) error
+}
 
 // Service orchestrates the deposit lifecycle, combining the transaction
 // repository with the Stripe client. Handlers must never call Stripe directly.
 type Service struct {
 	repo   Repository
-	stripe *stripeclient.Client
+	stripe stripeDepositor
 }
 
 // NewService creates a Service with the given repository and Stripe client.
-func NewService(repo Repository, stripe *stripeclient.Client) *Service {
+func NewService(repo Repository, stripe stripeDepositor) *Service {
 	return &Service{repo: repo, stripe: stripe}
 }
 

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -1,0 +1,31 @@
+package transactions_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/isw2-unileon/neighborlink/backend/internal/transactions"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeStripe struct {
+	capturedAmount int64
+}
+
+func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error) {
+	f.capturedAmount = amountCents
+	return "pi_fake", nil
+}
+
+func (f *fakeStripe) CaptureDeposit(_ string) error  { return nil }
+func (f *fakeStripe) ReleaseDeposit(_ string, _ int64) error { return nil }
+
+func TestAgreeDeal_ChargesDepositPlusPlatformFee(t *testing.T) {
+	fs := &fakeStripe{}
+	svc := transactions.NewService(&fakeRepository{}, fs)
+
+	_, err := svc.AgreeDeal(context.Background(), "listing-1", "user-1", "pm_test", 500)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(700), fs.capturedAmount) // 500 deposit + 200 platform fee
+}

--- a/docs/database_diagram.html
+++ b/docs/database_diagram.html
@@ -57,6 +57,7 @@ const diagram = `erDiagram
     timestamp return_at
     text stripe_payment_intent_id
     text payment_method_id
+    int8 total_charged_cents
   }
   messages {
     uuid id PK

--- a/frontend/src/pages/listings/ListingDetailPage.tsx
+++ b/frontend/src/pages/listings/ListingDetailPage.tsx
@@ -206,9 +206,13 @@ export default function ListingDetailPage() {
                             {listing.category?.replace(/_/g, ' ') ?? 'Sin categoría'}
                         </span>
                     </div>
-                    <p className="mt-4 text-xl font-semibold text-blue-600">
-                        {listing.deposit_amount} € depósito
-                    </p>
+                    <div className="mt-4 space-y-1">
+                        <p className="text-sm text-gray-600">Depósito: {listing.deposit_amount} €</p>
+                        <p className="text-sm text-gray-600">Tarifa de gestión: 2 €</p>
+                        <p className="text-xl font-semibold text-blue-600">
+                            Total: {listing.deposit_amount + 2} €
+                        </p>
+                    </div>
 
                     {isOwner && (
                         <div className="mt-6 flex gap-3">


### PR DESCRIPTION
Closes #36 

Adds a fixed €2 platform fee on top of the deposit charged to the borrower at agreement time.

**Backend**

- PlatformFeeCents = 200 constant added to the transaction domain.
- AgreeDeal now authorizes depositAmountCents + 200 on Stripe instead of the deposit alone.
- New total_charged_cents column on transactions — persisted when the deal is agreed, surfaced in all queries and the Transaction struct.
- Extracted stripeDepositor interface so the service is testable without a real Stripe key.

**Test**

- TestAgreeDeal_ChargesDepositPlusPlatformFee — asserts a 500-cent deposit results in a 700-cent Stripe authorization.

**Frontend**

- Listing detail page now shows a three-line breakdown: deposit / management fee / total.