### PR TITLE
[US-05] Lending request flow – POST/accept/reject transaction endpoints

### DIFF
--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -118,6 +118,20 @@ func (h *Handler) createTransaction(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"data": t})
 }
 
+// handleServiceError maps service-layer errors to HTTP responses.
+func (h *Handler) handleServiceError(c *gin.Context, action, id string, err error) {
+	slog.Error("failed to "+action+" transaction", "id", id, "error", err)
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "not found"):
+		c.JSON(http.StatusNotFound, gin.H{"error": msg})
+	case strings.Contains(msg, "status"):
+		c.JSON(http.StatusConflict, gin.H{"error": msg})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+	}
+}
+
 // requireOwner checks that the authenticated caller is the listing owner for the
 // given transaction. It writes the appropriate error response and returns false
 // when the caller should stop processing.
@@ -155,16 +169,7 @@ func (h *Handler) acceptTransaction(c *gin.Context) {
 	}
 
 	if err := h.service.Accept(c.Request.Context(), id, body.DepositAmountCents); err != nil {
-		slog.Error("failed to accept transaction", "id", id, "error", err)
-		msg := err.Error()
-		switch {
-		case strings.Contains(msg, "not found"):
-			c.JSON(http.StatusNotFound, gin.H{"error": msg})
-		case strings.Contains(msg, "status"):
-			c.JSON(http.StatusConflict, gin.H{"error": msg})
-		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		}
+		h.handleServiceError(c, "accept", id, err)
 		return
 	}
 
@@ -178,16 +183,7 @@ func (h *Handler) rejectTransaction(c *gin.Context) {
 	}
 
 	if err := h.service.Reject(c.Request.Context(), id); err != nil {
-		slog.Error("failed to reject transaction", "id", id, "error", err)
-		msg := err.Error()
-		switch {
-		case strings.Contains(msg, "not found"):
-			c.JSON(http.StatusNotFound, gin.H{"error": msg})
-		case strings.Contains(msg, "status"):
-			c.JSON(http.StatusConflict, gin.H{"error": msg})
-		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		}
+		h.handleServiceError(c, "reject", id, err)
 		return
 	}
 
@@ -201,16 +197,7 @@ func (h *Handler) handoverTransaction(c *gin.Context) {
 	}
 
 	if err := h.service.Handover(c.Request.Context(), id); err != nil {
-		slog.Error("failed to handover transaction", "id", id, "error", err)
-		msg := err.Error()
-		switch {
-		case strings.Contains(msg, "not found"):
-			c.JSON(http.StatusNotFound, gin.H{"error": msg})
-		case strings.Contains(msg, "status"):
-			c.JSON(http.StatusConflict, gin.H{"error": msg})
-		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		}
+		h.handleServiceError(c, "handover", id, err)
 		return
 	}
 
@@ -233,16 +220,7 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 	}
 
 	if err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents); err != nil {
-		slog.Error("failed to return transaction", "id", id, "error", err)
-		msg := err.Error()
-		switch {
-		case strings.Contains(msg, "not found"):
-			c.JSON(http.StatusNotFound, gin.H{"error": msg})
-		case strings.Contains(msg, "status"):
-			c.JSON(http.StatusConflict, gin.H{"error": msg})
-		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
-		}
+		h.handleServiceError(c, "return", id, err)
 		return
 	}
 

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -118,21 +118,30 @@ func (h *Handler) createTransaction(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"data": t})
 }
 
-func (h *Handler) acceptTransaction(c *gin.Context) {
-	id := c.Param("id")
-
+// requireOwner checks that the authenticated caller is the listing owner for the
+// given transaction. It writes the appropriate error response and returns false
+// when the caller should stop processing.
+func (h *Handler) requireOwner(c *gin.Context, id string) bool {
 	callerID, ok := c.Get("userID")
 	if !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return
+		return false
 	}
 	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
-		return
+		return false
 	}
 	if ownerID != callerID.(string) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return false
+	}
+	return true
+}
+
+func (h *Handler) acceptTransaction(c *gin.Context) {
+	id := c.Param("id")
+	if !h.requireOwner(c, id) {
 		return
 	}
 
@@ -164,19 +173,7 @@ func (h *Handler) acceptTransaction(c *gin.Context) {
 
 func (h *Handler) rejectTransaction(c *gin.Context) {
 	id := c.Param("id")
-
-	callerID, ok := c.Get("userID")
-	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return
-	}
-	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
-		return
-	}
-	if ownerID != callerID.(string) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	if !h.requireOwner(c, id) {
 		return
 	}
 
@@ -199,19 +196,7 @@ func (h *Handler) rejectTransaction(c *gin.Context) {
 
 func (h *Handler) handoverTransaction(c *gin.Context) {
 	id := c.Param("id")
-
-	callerID, ok := c.Get("userID")
-	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return
-	}
-	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
-		return
-	}
-	if ownerID != callerID.(string) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	if !h.requireOwner(c, id) {
 		return
 	}
 
@@ -234,19 +219,7 @@ func (h *Handler) handoverTransaction(c *gin.Context) {
 
 func (h *Handler) returnTransaction(c *gin.Context) {
 	id := c.Param("id")
-
-	callerID, ok := c.Get("userID")
-	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return
-	}
-	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
-	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
-		return
-	}
-	if ownerID != callerID.(string) {
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	if !h.requireOwner(c, id) {
 		return
 	}
 

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -29,6 +29,8 @@ func (h *Handler) RegisterRoutes(rg *gin.RouterGroup, authMiddleware gin.Handler
 	protected := rg.Group("/")
 	protected.Use(authMiddleware)
 	protected.POST("/transactions", h.createTransaction)
+	protected.PUT("/transactions/:id/accept", h.acceptTransaction)
+	protected.PUT("/transactions/:id/reject", h.rejectTransaction)
 	protected.POST("/transactions/:id/handover", h.handoverTransaction)
 	protected.POST("/transactions/:id/return", h.returnTransaction)
 }
@@ -93,9 +95,8 @@ func (h *Handler) createTransaction(c *gin.Context) {
 	borrowerID := userID.(string)
 
 	var body struct {
-		ListingID          string `json:"listing_id"`
-		PaymentMethodID    string `json:"payment_method_id"`
-		DepositAmountCents int64  `json:"deposit_amount_cents"`
+		ListingID       string `json:"listing_id"`
+		PaymentMethodID string `json:"payment_method_id"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		slog.Error("failed to parse create transaction body", "error", err)
@@ -103,14 +104,97 @@ func (h *Handler) createTransaction(c *gin.Context) {
 		return
 	}
 
-	t, err := h.service.AgreeDeal(c.Request.Context(), body.ListingID, borrowerID, body.PaymentMethodID, body.DepositAmountCents)
+	t, err := h.repo.Create(c.Request.Context(), Transaction{
+		ListingID:       body.ListingID,
+		BorrowerID:      borrowerID,
+		PaymentMethodID: body.PaymentMethodID,
+	})
 	if err != nil {
-		slog.Error("failed to agree deal", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		slog.Error("failed to create transaction", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		return
 	}
 
 	c.JSON(http.StatusCreated, gin.H{"data": t})
+}
+
+func (h *Handler) acceptTransaction(c *gin.Context) {
+	id := c.Param("id")
+
+	callerID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+		return
+	}
+	if ownerID != callerID.(string) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	var body struct {
+		DepositAmountCents int64 `json:"deposit_amount_cents"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		slog.Error("failed to parse accept transaction body", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.service.Accept(c.Request.Context(), id, body.DepositAmountCents); err != nil {
+		slog.Error("failed to accept transaction", "id", id, "error", err)
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
+			c.JSON(http.StatusNotFound, gin.H{"error": msg})
+		case strings.Contains(msg, "status"):
+			c.JSON(http.StatusConflict, gin.H{"error": msg})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
+}
+
+func (h *Handler) rejectTransaction(c *gin.Context) {
+	id := c.Param("id")
+
+	callerID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	ownerID, err := h.repo.FindListingOwnerByTransactionID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "transaction not found"})
+		return
+	}
+	if ownerID != callerID.(string) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
+	if err := h.service.Reject(c.Request.Context(), id); err != nil {
+		slog.Error("failed to reject transaction", "id", id, "error", err)
+		msg := err.Error()
+		switch {
+		case strings.Contains(msg, "not found"):
+			c.JSON(http.StatusNotFound, gin.H{"error": msg})
+		case strings.Contains(msg, "status"):
+			c.JSON(http.StatusConflict, gin.H{"error": msg})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msg})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"success": true})
 }
 
 func (h *Handler) handoverTransaction(c *gin.Context) {

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -118,6 +118,20 @@ func (h *Handler) createTransaction(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"data": t})
 }
 
+// parseDepositAmountCents reads deposit_amount_cents from the JSON body.
+// Returns the amount and true on success; writes a 400 response and returns false on failure.
+func (h *Handler) parseDepositAmountCents(c *gin.Context) (int64, bool) {
+	var body struct {
+		DepositAmountCents int64 `json:"deposit_amount_cents"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		slog.Error("failed to parse transaction body", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return 0, false
+	}
+	return body.DepositAmountCents, true
+}
+
 // handleServiceError maps service-layer errors to HTTP responses.
 func (h *Handler) handleServiceError(c *gin.Context, action, id string, err error) {
 	slog.Error("failed to "+action+" transaction", "id", id, "error", err)
@@ -159,16 +173,12 @@ func (h *Handler) acceptTransaction(c *gin.Context) {
 		return
 	}
 
-	var body struct {
-		DepositAmountCents int64 `json:"deposit_amount_cents"`
-	}
-	if err := c.ShouldBindJSON(&body); err != nil {
-		slog.Error("failed to parse accept transaction body", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	depositAmountCents, ok := h.parseDepositAmountCents(c)
+	if !ok {
 		return
 	}
 
-	if err := h.service.Accept(c.Request.Context(), id, body.DepositAmountCents); err != nil {
+	if err := h.service.Accept(c.Request.Context(), id, depositAmountCents); err != nil {
 		h.handleServiceError(c, "accept", id, err)
 		return
 	}
@@ -210,16 +220,12 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 		return
 	}
 
-	var body struct {
-		DepositAmountCents int64 `json:"deposit_amount_cents"`
-	}
-	if err := c.ShouldBindJSON(&body); err != nil {
-		slog.Error("failed to parse return transaction body", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	depositAmountCents, ok := h.parseDepositAmountCents(c)
+	if !ok {
 		return
 	}
 
-	if err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents); err != nil {
+	if err := h.service.Return(c.Request.Context(), id, depositAmountCents); err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -288,13 +288,117 @@ func TestListByBorrower(t *testing.T) {
 func TestCreateTransaction_RequiresAuth(t *testing.T) {
 	router := setupRouter(&fakeRepository{})
 
-	body := `{"listing_id":"l-1","payment_method_id":"pm_test","deposit_amount_cents":5000}`
+	body := `{"listing_id":"l-1","payment_method_id":"pm_test"}`
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/transactions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestCreateTransaction_CreatesPendingRecord(t *testing.T) {
+	router := setupRouter(&fakeRepository{})
+
+	body := `{"listing_id":"l-1","payment_method_id":"pm_test"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp struct {
+		Data transactions.Transaction `json:"data"`
+	}
+	err := json.NewDecoder(w.Body).Decode(&resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "pending", resp.Data.Status)
+}
+
+func TestAcceptTransaction_RequiresAuth(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/accept", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestAcceptTransaction_ForbidsNonOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/accept", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("other-user"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestAcceptTransaction_AllowsOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/accept", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}
+
+func TestRejectTransaction_RequiresAuth(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/reject", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestRejectTransaction_ForbidsNonOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/reject", nil)
+	req.Header.Set("Authorization", makeToken("other-user"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRejectTransaction_AllowsOwner(t *testing.T) {
+	router := setupRouter(&fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/reject", nil)
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.NotEqual(t, http.StatusUnauthorized, w.Code)
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
 }
 
 func TestHandoverTransaction_RequiresAuth(t *testing.T) {

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -105,12 +105,12 @@ func (r *postgresRepository) FindByBorrower(ctx context.Context, borrowerID stri
 func (r *postgresRepository) Create(ctx context.Context, t Transaction) (*Transaction, error) {
 	var created Transaction
 	err := r.pool.QueryRow(ctx, `
-		INSERT INTO transactions (listing_id, borrower_id, status)
-		VALUES ($1, $2, 'pending')
-		RETURNING id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
-	`, t.ListingID, t.BorrowerID).Scan(
+		INSERT INTO transactions (listing_id, borrower_id, payment_method_id, status)
+		VALUES ($1, $2, $3, 'pending')
+		RETURNING id, listing_id, borrower_id, status, payment_method_id, total_charged_cents, agreed_at, handover_at, return_at
+	`, t.ListingID, t.BorrowerID, t.PaymentMethodID).Scan(
 		&created.ID, &created.ListingID, &created.BorrowerID, &created.Status,
-		&created.TotalChargedCents, &created.AgreedAt, &created.HandoverAt, &created.ReturnAt,
+		&created.PaymentMethodID, &created.TotalChargedCents, &created.AgreedAt, &created.HandoverAt, &created.ReturnAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("transactions: insert failed: %w", err)

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -47,10 +47,10 @@ func (r *postgresRepository) FindAll(ctx context.Context) ([]Transaction, error)
 func (r *postgresRepository) FindByID(ctx context.Context, id string) (*Transaction, error) {
 	var t Transaction
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, listing_id, borrower_id, status, total_charged_cents, agreed_at, handover_at, return_at
+		SELECT id, listing_id, borrower_id, status, stripe_payment_intent_id, payment_method_id, total_charged_cents, agreed_at, handover_at, return_at
 		FROM transactions
 		WHERE id = $1
-	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.TotalChargedCents, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt)
+	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status, &t.StripePaymentIntentID, &t.PaymentMethodID, &t.TotalChargedCents, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt)
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -25,35 +25,43 @@ func NewService(repo Repository, stripe stripeDepositor) *Service {
 	return &Service{repo: repo, stripe: stripe}
 }
 
-// TODO: borrower_id is currently passed by the handler from a temporary header.
-// When JWT is implemented it must be extracted from the token instead.
-
-// AgreeDeal creates a pending transaction, authorizes the deposit on Stripe,
-// and marks the transaction as agreed.
-func (s *Service) AgreeDeal(ctx context.Context, listingID, borrowerID, paymentMethodID string, depositAmountCents int64) (*Transaction, error) {
-	t, err := s.repo.Create(ctx, Transaction{
-		ListingID:  listingID,
-		BorrowerID: borrowerID,
-	})
+// Accept authorizes the deposit on Stripe for a pending transaction and marks it as agreed.
+// The transaction must already exist in pending status with a stored payment_method_id.
+func (s *Service) Accept(ctx context.Context, transactionID string, depositAmountCents int64) error {
+	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
-		return nil, fmt.Errorf("service: create transaction: %w", err)
+		return fmt.Errorf("service: find transaction: %w", err)
+	}
+	if t == nil || t.Status != "pending" {
+		return fmt.Errorf("service: transaction %s must be in pending status to accept", transactionID)
 	}
 
 	totalCents := depositAmountCents + PlatformFeeCents
-	paymentIntentID, err := s.stripe.AuthorizeDeposit(totalCents, "eur", paymentMethodID)
+	paymentIntentID, err := s.stripe.AuthorizeDeposit(totalCents, "eur", t.PaymentMethodID)
 	if err != nil {
-		return nil, fmt.Errorf("service: authorize deposit: %w", err)
+		return fmt.Errorf("service: authorize deposit: %w", err)
 	}
 
-	if err := s.repo.UpdatePaymentIntent(ctx, t.ID, paymentIntentID, paymentMethodID, totalCents); err != nil {
-		return nil, fmt.Errorf("service: update payment intent: %w", err)
+	if err := s.repo.UpdatePaymentIntent(ctx, transactionID, paymentIntentID, t.PaymentMethodID, totalCents); err != nil {
+		return fmt.Errorf("service: update payment intent: %w", err)
+	}
+	return nil
+}
+
+// Reject cancels a pending transaction without any payment action.
+func (s *Service) Reject(ctx context.Context, transactionID string) error {
+	t, err := s.repo.FindByID(ctx, transactionID)
+	if err != nil {
+		return fmt.Errorf("service: find transaction: %w", err)
+	}
+	if t == nil || t.Status != "pending" {
+		return fmt.Errorf("service: transaction %s must be in pending status to reject", transactionID)
 	}
 
-	t.StripePaymentIntentID = paymentIntentID
-	t.PaymentMethodID = paymentMethodID
-	t.TotalChargedCents = totalCents
-	t.Status = "agreed"
-	return t, nil
+	if err := s.repo.UpdateStatus(ctx, transactionID, "cancelled"); err != nil {
+		return fmt.Errorf("service: update status: %w", err)
+	}
+	return nil
 }
 
 // Handover captures the authorized deposit and marks the transaction as handed_over.

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -17,15 +17,60 @@ func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethod
 	return "pi_fake", nil
 }
 
-func (f *fakeStripe) CaptureDeposit(_ string) error  { return nil }
+func (f *fakeStripe) CaptureDeposit(_ string) error          { return nil }
 func (f *fakeStripe) ReleaseDeposit(_ string, _ int64) error { return nil }
 
-func TestAgreeDeal_ChargesDepositPlusPlatformFee(t *testing.T) {
+func TestAccept_ChargesDepositPlusPlatformFee(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "pending", PaymentMethodID: "pm_test"},
+		},
+	}
 	fs := &fakeStripe{}
-	svc := transactions.NewService(&fakeRepository{}, fs)
+	svc := transactions.NewService(repo, fs)
 
-	_, err := svc.AgreeDeal(context.Background(), "listing-1", "user-1", "pm_test", 500)
+	err := svc.Accept(context.Background(), "tx-1", 500)
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(700), fs.capturedAmount) // 500 deposit + 200 platform fee
+}
+
+func TestAccept_FailsIfNotPending(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed", PaymentMethodID: "pm_test"},
+		},
+	}
+	svc := transactions.NewService(repo, &fakeStripe{})
+
+	err := svc.Accept(context.Background(), "tx-1", 500)
+
+	assert.Error(t, err)
+}
+
+func TestReject_SetsCancelledStatus(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "pending"},
+		},
+	}
+	svc := transactions.NewService(repo, &fakeStripe{})
+
+	err := svc.Reject(context.Background(), "tx-1")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "cancelled", repo.transactions[0].Status)
+}
+
+func TestReject_FailsIfNotPending(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed"},
+		},
+	}
+	svc := transactions.NewService(repo, &fakeStripe{})
+
+	err := svc.Reject(context.Background(), "tx-1")
+
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary

Implements the lending request flow so a borrower can send a transaction request
to an owner, and the owner can accept or reject it before any payment is processed.

Previous code (from US-14) combined create + Stripe payment authorisation into a
single `POST /api/transactions` call (`AgreeDeal`). This PR splits that into the
correct two-phase flow.

## Changes

- **`POST /api/transactions`** — creates a `pending` transaction (no Stripe); stores
  `payment_method_id` for later use at acceptance time.
- **`PUT /api/transactions/:id/accept`** — owner-only; authorises the Stripe deposit
  and transitions the transaction to `agreed`.
- **`PUT /api/transactions/:id/reject`** — owner-only; transitions the transaction to
  `cancelled` with no payment action.
- **Bugfix:** `FindByID` was not selecting `stripe_payment_intent_id` or
  `payment_method_id`, so `Handover` was always calling Stripe with an empty string.
  Fixed as part of this PR.
- All new endpoints are protected by JWT middleware; only the listing owner can
  accept or reject.

## Tests

- `TestAccept_ChargesDepositPlusPlatformFee` — verifies deposit + platform fee (500 + 200 = 700 cts)
- `TestAccept_FailsIfNotPending` — rejects non-pending transactions
- `TestReject_SetsCancelledStatus` — verifies status transition to `cancelled`
- `TestReject_FailsIfNotPending` — rejects non-pending transactions
- `TestCreateTransaction_CreatesPendingRecord` — happy path for the new create flow
- `TestAcceptTransaction_Requires Auth / ForbidsNonOwner / AllowsOwner`
- `TestRejectTransaction_RequiresAuth / ForbidsNonOwner / AllowsOwner`

## Closes

Closes #12
