### PR TITLE
Us 15 money distribution after loan

### DIFF
--- a/backend/internal/platform/stripe/client.go
+++ b/backend/internal/platform/stripe/client.go
@@ -55,13 +55,14 @@ func (c *Client) CaptureDeposit(paymentIntentID string) error {
 	return nil
 }
 
-// ReleaseDeposit refunds 95% of the captured amount to the borrower.
-// The remaining 5% stays as platform income (to be distributed to the lender separately).
+// ReleaseDeposit refunds (96 - daysBorrowed)% of the deposit to the borrower.
+// The platform keeps the €2 management fee and the lender's share is credited as wallet points.
 // Call this when the return QR is scanned successfully.
 // paymentIntentID is the pi_... value stored in the transactions table.
-// totalAmountCents is the original deposit amount in the smallest currency unit.
-func (c *Client) ReleaseDeposit(paymentIntentID string, totalAmountCents int64) error {
-	refundAmount := totalAmountCents * 95 / 100
+// depositAmountCents is the deposit (excluding the €2 platform fee).
+// daysBorrowed must be in [1, 7].
+func (c *Client) ReleaseDeposit(paymentIntentID string, depositAmountCents int64, daysBorrowed int) error {
+	refundAmount := depositAmountCents * int64(96-daysBorrowed) / 100
 
 	params := &stripe.RefundParams{
 		PaymentIntent: stripe.String(paymentIntentID),

--- a/backend/internal/platform/stripe/client.go
+++ b/backend/internal/platform/stripe/client.go
@@ -55,14 +55,13 @@ func (c *Client) CaptureDeposit(paymentIntentID string) error {
 	return nil
 }
 
-// ReleaseDeposit refunds (96 - daysBorrowed)% of the deposit to the borrower.
+// ReleaseDeposit issues a partial refund of refundAmountCents to the borrower.
 // The platform keeps the €2 management fee and the lender's share is credited as wallet points.
 // Call this when the return QR is scanned successfully.
 // paymentIntentID is the pi_... value stored in the transactions table.
-// depositAmountCents is the deposit (excluding the €2 platform fee).
-// daysBorrowed must be in [1, 7].
-func (c *Client) ReleaseDeposit(paymentIntentID string, depositAmountCents int64, daysBorrowed int) error {
-	refundAmount := depositAmountCents * int64(96-daysBorrowed) / 100
+// refundAmountCents is the pre-computed refund amount (calculated by the service).
+func (c *Client) ReleaseDeposit(paymentIntentID string, refundAmountCents int64) error {
+	refundAmount := refundAmountCents
 
 	params := &stripe.RefundParams{
 		PaymentIntent: stripe.String(paymentIntentID),

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -273,14 +273,14 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.Return(c.Request.Context(), id, depositAmountCents); err != nil {
+	daysBorrowed, err := h.service.Return(c.Request.Context(), id, depositAmountCents)
+	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 
-	// requireOwner already validated that the caller IS the listing owner.
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(depositAmountCents * 5 / 100)
+	pointsEarned := int(depositAmountCents * int64(daysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}
@@ -454,12 +454,13 @@ func (h *Handler) confirmReturn(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid return code"})
 		return
 	}
-	if err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents); err != nil {
+	daysBorrowed, err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents)
+	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(body.DepositAmountCents * 5 / 100)
+	pointsEarned := int(body.DepositAmountCents * int64(daysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -898,9 +898,12 @@ func TestConfirmReturn_InvalidCode_Returns422(t *testing.T) {
 }
 
 func TestConfirmReturn_ValidCode_Returns200(t *testing.T) {
+	handoverAt := time.Now().Add(-24 * time.Hour)
 	router := setupRouter(&fakeRepository{
 		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
-		transactions:         []transactions.Transaction{{ID: "tx-1", Status: "handed_over"}},
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "handed_over", HandoverAt: &handoverAt},
+		},
 	})
 
 	body := `{"code":"123456","deposit_amount_cents":5000}`

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -3,12 +3,13 @@ package transactions
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type stripeDepositor interface {
 	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error)
 	CaptureDeposit(paymentIntentID string) error
-	ReleaseDeposit(paymentIntentID string, totalAmountCents int64) error
+	ReleaseDeposit(paymentIntentID string, depositAmountCents int64, daysBorrowed int) error
 }
 
 type listingStatusUpdater interface {
@@ -81,6 +82,21 @@ func isDevPaymentIntent(id string) bool {
 	return id == "" || id == "pi_test_fake_for_dev"
 }
 
+// calcDaysBorrowed returns the number of calendar days between handoverAt and returnAt,
+// clamped to [1, 7] as per the loan policy.
+func calcDaysBorrowed(handoverAt, returnAt time.Time) int {
+	handoverDay := handoverAt.UTC().Truncate(24 * time.Hour)
+	returnDay := returnAt.UTC().Truncate(24 * time.Hour)
+	days := int(returnDay.Sub(handoverDay).Hours() / 24)
+	if days < 1 {
+		return 1
+	}
+	if days > 7 {
+		return 7
+	}
+	return days
+}
+
 // Handover captures the authorized deposit, marks the transaction as handed_over
 // and updates the listing status to pending_return.
 func (s *Service) Handover(ctx context.Context, transactionID string) error {
@@ -108,29 +124,32 @@ func (s *Service) Handover(ctx context.Context, transactionID string) error {
 	return nil
 }
 
-// Return refunds 95% of the deposit to the borrower, marks the transaction as returned
-// and updates the listing status back to available.
-func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) error {
+// Return refunds a variable percentage of the deposit to the borrower based on days borrowed,
+// marks the transaction as returned, and updates the listing status back to available.
+// Returns the number of days borrowed so the caller can compute the lender's points.
+func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) (int, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
-		return fmt.Errorf("service: find transaction: %w", err)
+		return 0, fmt.Errorf("service: find transaction: %w", err)
 	}
 	if t == nil || t.Status != "handed_over" {
-		return fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
+		return 0, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
 	}
 
+	daysBorrowed := calcDaysBorrowed(*t.HandoverAt, time.Now())
+
 	if !isDevPaymentIntent(t.StripePaymentIntentID) {
-		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, depositAmountCents); err != nil {
-			return fmt.Errorf("service: release deposit: %w", err)
+		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, depositAmountCents, daysBorrowed); err != nil {
+			return 0, fmt.Errorf("service: release deposit: %w", err)
 		}
 	}
 
 	if err := s.repo.UpdateStatus(ctx, transactionID, "returned"); err != nil {
-		return fmt.Errorf("service: update status: %w", err)
+		return 0, fmt.Errorf("service: update status: %w", err)
 	}
 
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "available"); err != nil {
-		return fmt.Errorf("service: update listing status: %w", err)
+		return 0, fmt.Errorf("service: update listing status: %w", err)
 	}
-	return nil
+	return daysBorrowed, nil
 }

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -9,7 +9,7 @@ import (
 type stripeDepositor interface {
 	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error)
 	CaptureDeposit(paymentIntentID string) error
-	ReleaseDeposit(paymentIntentID string, depositAmountCents int64, daysBorrowed int) error
+	ReleaseDeposit(paymentIntentID string, refundAmountCents int64) error
 }
 
 type listingStatusUpdater interface {
@@ -137,9 +137,10 @@ func (s *Service) Return(ctx context.Context, transactionID string, depositAmoun
 	}
 
 	daysBorrowed := calcDaysBorrowed(*t.HandoverAt, time.Now())
+	refundAmountCents := depositAmountCents * int64(96-daysBorrowed) / 100
 
 	if !isDevPaymentIntent(t.StripePaymentIntentID) {
-		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, depositAmountCents, daysBorrowed); err != nil {
+		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, refundAmountCents); err != nil {
 			return 0, fmt.Errorf("service: release deposit: %w", err)
 		}
 	}

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -3,6 +3,7 @@ package transactions_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/isw2-unileon/neighborlink/backend/internal/transactions"
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,8 @@ import (
 
 type fakeStripe struct {
 	capturedAmount int64
+	releasedAmount int64
+	releasedDays   int
 }
 
 func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error) {
@@ -17,8 +20,12 @@ func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethod
 	return "pi_fake", nil
 }
 
-func (f *fakeStripe) CaptureDeposit(_ string) error          { return nil }
-func (f *fakeStripe) ReleaseDeposit(_ string, _ int64) error { return nil }
+func (f *fakeStripe) CaptureDeposit(_ string) error { return nil }
+func (f *fakeStripe) ReleaseDeposit(_ string, amount int64, days int) error {
+	f.releasedAmount = amount
+	f.releasedDays = days
+	return nil
+}
 
 type fakeListingSvc struct{}
 
@@ -108,6 +115,136 @@ func TestReject_FailsIfNotPending(t *testing.T) {
 	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{})
 
 	err := svc.Reject(context.Background(), "tx-1")
+
+	assert.Error(t, err)
+}
+
+// --- Return ---
+
+func TestReturn_VariableRefundByDays(t *testing.T) {
+	cases := []struct {
+		days            int
+		deposit         int64
+		wantRefund      int64
+		wantDayReturned int
+	}{
+		{days: 1, deposit: 10000, wantRefund: 9500, wantDayReturned: 1}, // 95%
+		{days: 2, deposit: 10000, wantRefund: 9400, wantDayReturned: 2}, // 94%
+		{days: 3, deposit: 10000, wantRefund: 9300, wantDayReturned: 3}, // 93%
+		{days: 4, deposit: 10000, wantRefund: 9200, wantDayReturned: 4}, // 92%
+		{days: 5, deposit: 10000, wantRefund: 9100, wantDayReturned: 5}, // 91%
+		{days: 6, deposit: 10000, wantRefund: 9000, wantDayReturned: 6}, // 90%
+		{days: 7, deposit: 10000, wantRefund: 8900, wantDayReturned: 7}, // 89%
+	}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			handoverAt := time.Now().UTC().AddDate(0, 0, -tc.days)
+			repo := &fakeRepository{
+				transactions: []transactions.Transaction{
+					{
+						ID:                    "tx-1",
+						Status:                "handed_over",
+						StripePaymentIntentID: "pi_fake",
+						ListingID:             "lst-1",
+						HandoverAt:            &handoverAt,
+					},
+				},
+			}
+			fs := &fakeStripe{}
+			svc := transactions.NewService(repo, fs, &fakeListingSvc{})
+
+			daysBorrowed, err := svc.Return(context.Background(), "tx-1", tc.deposit)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantDayReturned, daysBorrowed)
+			assert.Equal(t, tc.wantRefund, fs.releasedAmount)
+			assert.Equal(t, tc.days, fs.releasedDays)
+		})
+	}
+}
+
+func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
+	// deposit is 10000; total charged would be 10200 (deposit + €2 fee).
+	// Only the deposit (not the fee) should be passed to ReleaseDeposit.
+	deposit := int64(10000)
+	handoverAt := time.Now().UTC().AddDate(0, 0, -1)
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{
+				ID:                    "tx-1",
+				Status:                "handed_over",
+				StripePaymentIntentID: "pi_fake",
+				ListingID:             "lst-1",
+				HandoverAt:            &handoverAt,
+			},
+		},
+	}
+	fs := &fakeStripe{}
+	svc := transactions.NewService(repo, fs, &fakeListingSvc{})
+
+	_, err := svc.Return(context.Background(), "tx-1", deposit)
+
+	assert.NoError(t, err)
+	// refundAmount must be strictly less than the deposit (fee not refunded, and lender keeps a share)
+	assert.Less(t, fs.releasedAmount, deposit)
+}
+
+func TestReturn_DaysClamped(t *testing.T) {
+	t.Run("same-day return clamps to 1", func(t *testing.T) {
+		handoverAt := time.Now().UTC() // same day
+		repo := &fakeRepository{
+			transactions: []transactions.Transaction{
+				{
+					ID:                    "tx-1",
+					Status:                "handed_over",
+					StripePaymentIntentID: "pi_fake",
+					ListingID:             "lst-1",
+					HandoverAt:            &handoverAt,
+				},
+			},
+		}
+		fs := &fakeStripe{}
+		svc := transactions.NewService(repo, fs, &fakeListingSvc{})
+
+		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 1, daysBorrowed)
+	})
+
+	t.Run("over-7-day return clamps to 7", func(t *testing.T) {
+		handoverAt := time.Now().UTC().AddDate(0, 0, -10)
+		repo := &fakeRepository{
+			transactions: []transactions.Transaction{
+				{
+					ID:                    "tx-1",
+					Status:                "handed_over",
+					StripePaymentIntentID: "pi_fake",
+					ListingID:             "lst-1",
+					HandoverAt:            &handoverAt,
+				},
+			},
+		}
+		fs := &fakeStripe{}
+		svc := transactions.NewService(repo, fs, &fakeListingSvc{})
+
+		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 7, daysBorrowed)
+	})
+}
+
+func TestReturn_FailsIfNotHandedOver(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed"},
+		},
+	}
+	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{})
+
+	_, err := svc.Return(context.Background(), "tx-1", 10000)
 
 	assert.Error(t, err)
 }

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -12,7 +12,6 @@ import (
 type fakeStripe struct {
 	capturedAmount int64
 	releasedAmount int64
-	releasedDays   int
 }
 
 func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error) {
@@ -21,9 +20,8 @@ func (f *fakeStripe) AuthorizeDeposit(amountCents int64, currency, paymentMethod
 }
 
 func (f *fakeStripe) CaptureDeposit(_ string) error { return nil }
-func (f *fakeStripe) ReleaseDeposit(_ string, amount int64, days int) error {
+func (f *fakeStripe) ReleaseDeposit(_ string, amount int64) error {
 	f.releasedAmount = amount
-	f.releasedDays = days
 	return nil
 }
 
@@ -159,7 +157,6 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.wantDayReturned, daysBorrowed)
 			assert.Equal(t, tc.wantRefund, fs.releasedAmount)
-			assert.Equal(t, tc.days, fs.releasedDays)
 		})
 	}
 }

--- a/backend/internal/wallet/postgres_repository.go
+++ b/backend/internal/wallet/postgres_repository.go
@@ -68,7 +68,11 @@ func (r *postgresRepository) CreateRedemption(ctx context.Context, userID string
 func (r *postgresRepository) GetPointsHistory(ctx context.Context, userID string) ([]PointsHistoryEntry, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT t.id, l.title, t.return_at,
-		       (t.total_charged_cents - 200) * 5 / 100 AS points_earned
+		       FLOOR(
+		         (t.total_charged_cents - 200) *
+		         (GREATEST(1, LEAST(7, (t.return_at::date - t.handover_at::date))) + 4)
+		         / 100.0
+		       ) AS points_earned
 		FROM transactions t
 		JOIN listings l ON t.listing_id = l.id
 		WHERE l.owner_id = $1 AND t.status = 'returned'


### PR DESCRIPTION
## Summary

Implements variable money distribution on loan return (US-15). Previously the refund was hardcoded at 95% and lender points at 5%. Now both scale with the actual number of days the item was borrowed.

- **Borrower** receives `deposit × (96 − days_borrowed) / 100` back via Stripe refund.
- **Lender** receives `floor(deposit × (days_borrowed + 4) / 100)` as wallet points.
- **Platform** keeps the fixed €2 management fee on every transaction (unchanged).
- `days_borrowed` = calendar days between `handover_at` and `return_at`, clamped to [1, 7].

## Changes

- **`stripe/client.go`** — `ReleaseDeposit` now accepts a pre-computed `refundAmountCents` instead of applying a hardcoded 95%. Removed the Stripe Connect TODO comment (lender is paid via wallet points, not a bank transfer).
- **`transactions/service.go`** — Added `calcDaysBorrowed(handoverAt, returnAt)` helper (clamped to [1, 7]). `Return` now computes `daysBorrowed` and `refundAmountCents` and returns `(int, error)` so the handler can derive the points amount.
- **`transactions/handler.go`** — Both `returnTransaction` and `confirmReturn` updated to use the variable formula `deposit × (days + 4) / 100` for lender points.
- **`wallet/postgres_repository.go`** — `GetPointsHistory` SQL updated to compute `points_earned` from `handover_at`/`return_at` columns instead of the old fixed 5% formula.
- **`transactions/service_test.go`** — Added `TestReturn_VariableRefundByDays` (table-driven, days 1–7), `TestReturn_PlatformFeeNotRefunded`, `TestReturn_DaysClamped`, and `TestReturn_FailsIfNotHandedOver`.
- **`transactions/handler_test.go`** — Fixed `TestConfirmReturn_ValidCode_Returns200` fixture to include `HandoverAt` (required by the new days calculation).

## Test plan

- [ ] `go test ./internal/transactions/... -v -run TestReturn` — all new Return tests pass for each day range
- [ ] `go test ./internal/...` — no regressions across all packages
- [ ] Manual: complete a loan flow end-to-end, confirm the refund amount and lender points match the table in the issue description

Closes #37 
