### PR TITLE
Us 18 stripe payments intents flow

### DIFF
--- a/backend/internal/platform/stripe/client.go
+++ b/backend/internal/platform/stripe/client.go
@@ -26,8 +26,8 @@ func NewClient(secretKey string) *Client {
 // This reserves the deposit amount on the borrower's card without charging it yet.
 // amountCents is the deposit amount in the smallest currency unit (e.g. cents for EUR).
 // paymentMethodID is the Stripe payment method ID (pm_...) provided by the borrower.
-// Returns the PaymentIntent ID (pi_...) that must be stored in the transactions table.
-func (c *Client) AuthorizeDeposit(amountCents int64, currency string, paymentMethodID string) (string, error) {
+// Returns the PaymentIntent ID (pi_...) and client_secret needed by the frontend for 3DS.
+func (c *Client) AuthorizeDeposit(amountCents int64, currency string, paymentMethodID string) (piID string, clientSecret string, err error) {
 	params := &stripe.PaymentIntentParams{
 		Amount:        stripe.Int64(amountCents),
 		Currency:      stripe.String(currency),
@@ -42,10 +42,10 @@ func (c *Client) AuthorizeDeposit(amountCents int64, currency string, paymentMet
 
 	pi, err := paymentintent.New(params)
 	if err != nil {
-		return "", fmt.Errorf("stripe: failed to authorize deposit: %w", err)
+		return "", "", fmt.Errorf("stripe: failed to authorize deposit: %w", err)
 	}
 
-	return pi.ID, nil
+	return pi.ID, pi.ClientSecret, nil
 }
 
 // CaptureDeposit captures a previously authorized PaymentIntent in full.

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -299,12 +299,13 @@ func (h *Handler) payTransaction(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID); err != nil {
+	clientSecret, err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID)
+	if err != nil {
 		h.handleServiceError(c, "pay", id, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"success": true})
+	c.JSON(http.StatusOK, gin.H{"client_secret": clientSecret})
 }
 
 func (h *Handler) acceptTransaction(c *gin.Context) {

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -804,6 +804,30 @@ func TestPayTransaction_Success(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	_, hasClientSecret := resp["client_secret"]
+	assert.True(t, hasClientSecret, "response must contain client_secret field")
+}
+
+func TestPayTransaction_ReturnsClientSecret(t *testing.T) {
+	router := setupRouterWithStripe(&fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", PaymentMethodID: "pm_test", ListingID: "lst-1"},
+		},
+	}, &fakeStripe{clientSecret: "pi_secret_handler_test"})
+
+	body := `{"deposit_amount_cents":5000, "payment_method_id": "pm_new"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/pay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "pi_secret_handler_test", resp["client_secret"])
 }
 
 func TestHandoverTransaction_Success(t *testing.T) {

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -7,7 +7,7 @@ import (
 )
 
 type stripeDepositor interface {
-	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (string, error)
+	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (piID string, clientSecret string, err error)
 	CaptureDeposit(paymentIntentID string) error
 	ReleaseDeposit(paymentIntentID string, refundAmountCents int64) error
 }
@@ -63,13 +63,13 @@ func (s *Service) AcceptRequest(ctx context.Context, transactionID string) error
 
 // ConfirmPayment autoriza el depósito en Stripe y mueve la transacción a agreed.
 // Solo puede llamarlo el borrower cuando status = awaiting_payment.
-func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string) error {
+func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string) (string, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
-		return fmt.Errorf("service: find transaction: %w", err)
+		return "", fmt.Errorf("service: find transaction: %w", err)
 	}
 	if t == nil || t.Status != "awaiting_payment" {
-		return fmt.Errorf("service: transaction %s must be in awaiting_payment status to pay", transactionID)
+		return "", fmt.Errorf("service: transaction %s must be in awaiting_payment status to pay", transactionID)
 	}
 
 	totalCents := depositAmountCents + PlatformFeeCents
@@ -79,23 +79,23 @@ func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depo
 	}
 
 	if actualPaymentMethodID == "" {
-		return fmt.Errorf("service: payment method ID is required")
+		return "", fmt.Errorf("service: payment method ID is required")
 	}
 
-	stripePIID, err := s.stripe.AuthorizeDeposit(totalCents, "eur", actualPaymentMethodID)
+	stripePIID, clientSecret, err := s.stripe.AuthorizeDeposit(totalCents, "eur", actualPaymentMethodID)
 	if err != nil {
-		return fmt.Errorf("service: authorize deposit: %w", err)
+		return "", fmt.Errorf("service: authorize deposit: %w", err)
 	}
 
 	if err := s.repo.UpdatePaymentIntent(ctx, transactionID, stripePIID, actualPaymentMethodID, totalCents); err != nil {
-		return fmt.Errorf("service: update payment intent: %w", err)
+		return "", fmt.Errorf("service: update payment intent: %w", err)
 	}
 
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "pending_handover"); err != nil {
-		return fmt.Errorf("service: update listing status: %w", err)
+		return "", fmt.Errorf("service: update listing status: %w", err)
 	}
 
-	return nil
+	return clientSecret, nil
 }
 
 // Reject cancels a pending transaction and updates its status to cancelled.

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -99,7 +99,7 @@ func TestConfirmPayment_ChargesDepositPlusPlatformFee(t *testing.T) {
 	lsvc := &fakeListingSvc{}
 	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(700), fs.capturedAmount) // 500 deposit + 200 platform fee
@@ -115,9 +115,25 @@ func TestConfirmPayment_FailsIfNotAwaitingPayment(t *testing.T) {
 	}
 	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
 
 	assert.Error(t, err)
+	assert.Empty(t, cs)
+}
+
+func TestConfirmPayment_ReturnsClientSecret(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", PaymentMethodID: "pm_test", ListingID: "lst-1"},
+		},
+	}
+	fs := &fakeStripe{clientSecret: "pi_secret_xyz_secret"}
+	svc := transactions.NewService(repo, fs, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
+
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "pi_secret_xyz_secret", cs)
 }
 
 // --- Reject ---

--- a/backend/internal/transactions/shared_test.go
+++ b/backend/internal/transactions/shared_test.go
@@ -42,10 +42,11 @@ type fakeStripe struct {
 	capturedAmount int64
 	releasedAmount int64
 	captureCalled  bool
+	clientSecret   string
 }
-func (f *fakeStripe) AuthorizeDeposit(amountCents int64, _, _ string) (string, error) {
+func (f *fakeStripe) AuthorizeDeposit(amountCents int64, _, _ string) (string, string, error) {
 	f.capturedAmount = amountCents
-	return "pi_fake", nil
+	return "pi_fake", f.clientSecret, nil
 }
 func (f *fakeStripe) CaptureDeposit(_ string) error {
 	f.captureCalled = true

--- a/frontend/src/__tests__/PaymentForm.test.tsx
+++ b/frontend/src/__tests__/PaymentForm.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import PaymentForm, { type PaymentFormHandle } from '../components/PaymentForm';
 
 const mockCreatePaymentMethod = vi.fn();
+const mockHandleNextAction = vi.fn();
 
 vi.mock('@stripe/stripe-js', () => ({
     loadStripe: vi.fn().mockResolvedValue(null),
@@ -15,7 +16,7 @@ vi.mock('@stripe/react-stripe-js', () => ({
     CardNumberElement: () => <div data-testid="card-number" />,
     CardExpiryElement: () => <div data-testid="card-expiry" />,
     CardCvcElement: () => <div data-testid="card-cvc" />,
-    useStripe: () => ({ createPaymentMethod: mockCreatePaymentMethod }),
+    useStripe: () => ({ createPaymentMethod: mockCreatePaymentMethod, handleNextAction: mockHandleNextAction }),
     useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
 }));
 
@@ -112,5 +113,31 @@ describe('PaymentForm.createPaymentMethod', () => {
         });
 
         await expect(promise).rejects.toThrow('Error de conexión. Comprueba tu red e inténtalo de nuevo.');
+    });
+});
+
+describe('PaymentForm.handleNextAction', () => {
+    it('resuelve sin error cuando no se requiere acción adicional', async () => {
+        mockHandleNextAction.mockResolvedValueOnce({ paymentIntent: { status: 'requires_capture' } });
+
+        const ref = renderPaymentForm();
+
+        await act(async () => {
+            await ref.current!.handleNextAction('pi_secret_abc');
+        });
+
+        expect(mockHandleNextAction).toHaveBeenCalledWith({ clientSecret: 'pi_secret_abc' });
+    });
+
+    it('lanza error localizado cuando Stripe devuelve error en handleNextAction', async () => {
+        mockHandleNextAction.mockResolvedValueOnce({
+            error: { code: 'card_declined', message: 'Your card was declined.' },
+        });
+
+        const ref = renderPaymentForm();
+
+        await expect(
+            act(async () => { await ref.current!.handleNextAction('pi_secret_abc'); })
+        ).rejects.toThrow('Tu tarjeta fue rechazada. Por favor, usa otra tarjeta.');
     });
 });

--- a/frontend/src/__tests__/transactions.test.ts
+++ b/frontend/src/__tests__/transactions.test.ts
@@ -66,7 +66,7 @@ describe('transactionsApi.pay', () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
-            json: async () => ({ success: true }),
+            json: async () => ({ client_secret: 'pi_secret_abc' }),
         });
 
         await transactionsApi.pay('tx-1', 5000, 'pm_123');
@@ -81,6 +81,18 @@ describe('transactionsApi.pay', () => {
                 }),
             })
         );
+    });
+
+    it('devuelve el clientSecret del backend', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ client_secret: 'pi_secret_abc' }),
+        });
+
+        const result = await transactionsApi.pay('tx-1', 5000, 'pm_123');
+
+        expect(result.clientSecret).toBe('pi_secret_abc');
     });
 
     it('lanza error si la respuesta no es ok', async () => {

--- a/frontend/src/components/PaymentForm.tsx
+++ b/frontend/src/components/PaymentForm.tsx
@@ -27,6 +27,7 @@ function mapStripeError(err: { code?: string; message?: string }): string {
 
 export interface PaymentFormHandle {
     createPaymentMethod(): Promise<string>;
+    handleNextAction(clientSecret: string): Promise<void>;
 }
 
 interface Props {
@@ -72,6 +73,11 @@ const PaymentFormInner = forwardRef<PaymentFormHandle, Props>(({ totalEuros }, r
 
             if (error) throw new Error(mapStripeError(error));
             return paymentMethod!.id;
+        },
+        async handleNextAction(clientSecret: string): Promise<void> {
+            if (!stripe) throw new Error('Stripe no está disponible.');
+            const { error } = await stripe.handleNextAction({ clientSecret });
+            if (error) throw new Error(mapStripeError(error));
         },
     }));
 

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -36,7 +36,8 @@ export default function PaymentModal({
         setError(null);
         try {
             const pmId = await paymentFormRef.current.createPaymentMethod();
-            await transactionsApi.pay(transactionId, depositCents, pmId);
+            const { clientSecret } = await transactionsApi.pay(transactionId, depositCents, pmId);
+            await paymentFormRef.current.handleNextAction(clientSecret);
             onSuccess();
         } catch (err: unknown) {
             setError(err instanceof Error ? err.message : 'Error al procesar el pago');

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -5,12 +5,11 @@ export const transactionsApi = {
     getById: (id: string): Promise<Transaction> =>
         api.get<{ data: Transaction }>(`/transactions/${id}`).then(r => r.data),
 
-    pay: (id: string, depositAmountCents: number, paymentMethodId: string): Promise<void> =>
-        api.put<unknown>(`/transactions/${id}/pay`, {
+    pay: (id: string, depositAmountCents: number, paymentMethodId: string): Promise<{ clientSecret: string }> =>
+        api.put<{ client_secret: string }>(`/transactions/${id}/pay`, {
             deposit_amount_cents: depositAmountCents,
             payment_method_id: paymentMethodId
-        })
-            .then(() => undefined),
+        }).then(r => ({ clientSecret: r.client_secret })),
 
     reportIssue: (id: string): Promise<void> =>
         api.post<unknown>(`/transactions/${id}/report-issue`, {})

--- a/frontend/src/pages/chats/ChatDetailPage.tsx
+++ b/frontend/src/pages/chats/ChatDetailPage.tsx
@@ -28,7 +28,7 @@ function MessageBubble({
 
     if (isSystem) {
         const isPaymentPrompt = message.content.toLowerCase().includes('métodos de pago');
-        const isAlreadyPaid = transactionStatus !== 'awaiting_payment' && transactionStatus !== 'pending';
+        const isAlreadyPaid = transactionStatus !== 'awaiting_payment';
         if (isPaymentPrompt && (isAlreadyPaid || !isBorrower)) return null;
 
         return (
@@ -498,7 +498,12 @@ export default function ChatDetailPage() {
                                 isMe={msg.sender_id === user.id}
                                 isBorrower={!isOwner}
                                 transactionStatus={transactionStatus}
-                                onOpenPayment={() => setShowPayment(true)}
+                                onOpenPayment={async () => {
+                                    if (!transactionId) return;
+                                    const t = await transactionsApi.getById(transactionId);
+                                    setTransaction(t);
+                                    if (t.status === 'awaiting_payment') setShowPayment(true);
+                                }}
                             />
                         ))}
                         <div ref={bottomRef} />


### PR DESCRIPTION
## Summary

Closes #64

Stripe Payment Intents were never created during test payments. Stripe logs only showed `POST /v1/payment_methods` (publishable key) with zero `POST /v1/payment_intents` or captures in the Dashboard.

Two root causes were identified and fixed:

- **`client_secret` was discarded at every layer.** `AuthorizeDeposit` returned only `pi.ID`; `pi.ClientSecret` was thrown away from the Stripe client all the way up to the HTTP response. The frontend never received it, so `stripe.handleNextAction()` was never called — meaning any card requiring 3DS SCA authentication silently failed without ever creating a PaymentIntent.
- **Payment button shown before status was confirmed.** `isAlreadyPaid` in `MessageBubble` showed the pay button for both `pending` and `awaiting_payment` states, and `onOpenPayment` never re-fetched the transaction from the server, leaving the frontend with potentially stale local state.

## Changes

### Backend
- `platform/stripe/client.go` — `AuthorizeDeposit` now returns `(piID, clientSecret string, err error)`.
- `transactions/service.go` — `stripeDepositor` interface updated; `ConfirmPayment` now returns `(string, error)` threading the `client_secret` to the caller.
- `transactions/handler.go` — `PUT /transactions/:id/pay` response changed from `{"success": true}` to `{"client_secret": "..."}`.

### Frontend
- `lib/transactions.ts` — `pay()` now returns `Promise<{ clientSecret: string }>` instead of `Promise<void>`.
- `components/PaymentForm.tsx` — New `handleNextAction(clientSecret)` method added to `PaymentFormHandle`, implemented via `useStripe()` inside the Elements context.
- `components/PaymentModal.tsx` — `handlePay()` calls `handleNextAction(clientSecret)` after the backend responds, completing 3DS authentication when required.
- `pages/chats/ChatDetailPage.tsx` — Pay button is now hidden unless `transactionStatus === 'awaiting_payment'` (previously also visible on `pending`). `onOpenPayment` re-fetches the transaction from the server before opening the modal.

### Tests
- `shared_test.go` — `fakeStripe.AuthorizeDeposit` updated to new three-value return signature.
- `service_test.go` — Existing `ConfirmPayment` tests updated; new `TestConfirmPayment_ReturnsClientSecret` added.
- `handler_test.go` — `TestPayTransaction_Success` asserts `client_secret` field is present; new `TestPayTransaction_ReturnsClientSecret` added.
- `transactions.test.ts` — Existing `pay()` test updated; new assertion on returned `clientSecret`.
- `PaymentForm.test.tsx` — `mockHandleNextAction` added to `useStripe` mock; two new tests covering success and `card_declined` error paths.

## Test plan

- [ ] `go build ./...` passes with no errors
- [ ] `go test ./internal/transactions/...` — all tests green
- [ ] `npm test` — all 177 tests green
- [ ] Manual: Stripe test card `4242 4242 4242 4242` (no 3DS) → PaymentIntent appears in Stripe Dashboard with status `requires_capture`
- [ ] Manual: Stripe test card `4000 0027 6000 3184` (3DS required) → 3DS modal appears, PaymentIntent reaches `requires_capture` after authentication
- [ ] Transaction status transitions from `awaiting_payment` → `agreed` after successful payment
- [ ] Pay button is not shown when local transaction status is `pending`

## Known limitation

For cards that trigger 3DS, `UpdatePaymentIntent` (which marks the transaction as `agreed`) runs on the backend before the frontend completes 3DS authentication. If the user cancels the 3DS dialog the transaction is left in `agreed` with an unconfirmed PaymentIntent. A proper fix would require listening to the `payment_intent.amount_capturable_updated` Stripe webhook and moving the status update there.