### PR TITLE
[TASK-14] Fix payment flow with mock credit card

### DIFF
--- a/frontend/src/__tests__/PaymentForm.test.tsx
+++ b/frontend/src/__tests__/PaymentForm.test.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import PaymentForm, { type PaymentFormHandle } from '../components/PaymentForm';
 
 const mockCreatePaymentMethod = vi.fn();
-const mockConfirmCardPayment = vi.fn();
+const mockHandleNextAction = vi.fn();
+const mockRetrievePaymentIntent = vi.fn();
 
 vi.mock('@stripe/stripe-js', () => ({
     loadStripe: vi.fn().mockResolvedValue(null),
@@ -16,8 +17,12 @@ vi.mock('@stripe/react-stripe-js', () => ({
     CardNumberElement: () => <div data-testid="card-number" />,
     CardExpiryElement: () => <div data-testid="card-expiry" />,
     CardCvcElement: () => <div data-testid="card-cvc" />,
-    useStripe: () => ({ createPaymentMethod: mockCreatePaymentMethod, confirmCardPayment: mockConfirmCardPayment }),
-    useElements: () => ({ getElement: vi.fn().mockReturnValue({ getElement: vi.fn() }) }),
+    useStripe: () => ({
+        createPaymentMethod: mockCreatePaymentMethod,
+        handleNextAction: mockHandleNextAction,
+        retrievePaymentIntent: mockRetrievePaymentIntent,
+    }),
+    useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
 }));
 
 beforeEach(() => {
@@ -117,8 +122,8 @@ describe('PaymentForm.createPaymentMethod', () => {
 });
 
 describe('PaymentForm.handleNextAction', () => {
-    it('resuelve sin error cuando no se requiere acción adicional', async () => {
-        mockConfirmCardPayment.mockResolvedValueOnce({ paymentIntent: { status: 'requires_capture' } });
+    it('resuelve sin llamar a handleNextAction cuando el PI está en requires_capture', async () => {
+        mockRetrievePaymentIntent.mockResolvedValueOnce({ paymentIntent: { status: 'requires_capture' } });
 
         const ref = renderPaymentForm();
 
@@ -126,19 +131,26 @@ describe('PaymentForm.handleNextAction', () => {
             await ref.current!.handleNextAction('pi_secret_abc');
         });
 
-        // Use asymmetricMatcher or deep partial check if necessary, but here we can be more specific
-        expect(mockConfirmCardPayment).toHaveBeenCalledWith(
-            'pi_secret_abc',
-            expect.objectContaining({
-                payment_method: expect.objectContaining({
-                    card: expect.anything(),
-                }),
-            })
-        );
+        expect(mockRetrievePaymentIntent).toHaveBeenCalledWith('pi_secret_abc');
+        expect(mockHandleNextAction).not.toHaveBeenCalled();
     });
 
-    it('lanza error localizado cuando Stripe devuelve error en confirmCardPayment', async () => {
-        mockConfirmCardPayment.mockResolvedValueOnce({
+    it('llama a handleNextAction cuando el PI está en requires_action', async () => {
+        mockRetrievePaymentIntent.mockResolvedValueOnce({ paymentIntent: { status: 'requires_action' } });
+        mockHandleNextAction.mockResolvedValueOnce({ paymentIntent: { status: 'requires_capture' } });
+
+        const ref = renderPaymentForm();
+
+        await act(async () => {
+            await ref.current!.handleNextAction('pi_secret_abc');
+        });
+
+        expect(mockHandleNextAction).toHaveBeenCalledWith({ clientSecret: 'pi_secret_abc' });
+    });
+
+    it('lanza error localizado cuando Stripe devuelve error en el paso 3DS', async () => {
+        mockRetrievePaymentIntent.mockResolvedValueOnce({ paymentIntent: { status: 'requires_action' } });
+        mockHandleNextAction.mockResolvedValueOnce({
             error: { code: 'card_declined', message: 'Your card was declined.' },
         });
 

--- a/frontend/src/components/PaymentForm.tsx
+++ b/frontend/src/components/PaymentForm.tsx
@@ -75,15 +75,11 @@ const PaymentFormInner = forwardRef<PaymentFormHandle, Props>(({ totalEuros }, r
             return paymentMethod!.id;
         },
         async handleNextAction(clientSecret: string): Promise<void> {
-            if (!stripe || !elements) throw new Error('Stripe no está disponible.');
-            
-            const cardElement = elements.getElement(CardNumberElement);
-            if (!cardElement) throw new Error('Stripe no está disponible.');
-
-            const { error } = await stripe.confirmCardPayment(clientSecret, {
-                payment_method: { card: cardElement },
-            });
-            
+            if (!stripe) throw new Error('Stripe no está disponible.');
+            const { paymentIntent, error: retrieveError } = await stripe.retrievePaymentIntent(clientSecret);
+            if (retrieveError) throw new Error(mapStripeError(retrieveError));
+            if (paymentIntent?.status !== 'requires_action') return;
+            const { error } = await stripe.handleNextAction({ clientSecret });
             if (error) throw new Error(mapStripeError(error));
         },
     }));


### PR DESCRIPTION
Closes #71 

## Summary

- `stripe.confirmCardPayment()` (and previously `stripe.handleNextAction()` unconditionally) was being called after a PaymentIntent already confirmed server-side, causing "Se ha producido un error de procesamiento" on every payment attempt.
- The backend creates PaymentIntents with `Confirm: true`, so for non-3DS cards (e.g. `4242 4242 4242 4242`) the PI is immediately in `requires_capture` — not `requires_action`. Calling any confirmation method on it fails.
- Secondary symptom: after the error, logging out and back in showed the payment as completed. This was actually correct — the backend authorization succeeded — but the frontend was showing a false error.

## Changes

- `PaymentForm.tsx` — `handleNextAction` now calls `stripe.retrievePaymentIntent(clientSecret)` first. If the PI is already in `requires_capture` it returns immediately (no-op). Only if status is `requires_action` does it call `stripe.handleNextAction({ clientSecret })` to trigger the 3DS modal.
- `PaymentForm.test.tsx` — updated mock to include `retrievePaymentIntent`; rewrote `handleNextAction` tests to cover: `requires_capture` (resolves without calling handleNextAction), `requires_action` + success (3DS flow called), `requires_action` + error (localized error thrown).

## Test plan

- [ ] `npm test` — all relevant suites green
- [ ] Manual: card `4242 4242 4242 4242` → payment completes with no error, transaction moves to `agreed`
- [ ] Manual: card `4000 0027 6000 3184` (3DS) → 3DS modal appears, payment completes after authentication
- [ ] Re-login after a successful payment shows transaction as `agreed` (consistent with backend state)