### PR TITLE
fix: payment flow, fixed deposit amount and refund by reservation days

### DIFF
--- a/backend/internal/platform/stripe/client.go
+++ b/backend/internal/platform/stripe/client.go
@@ -30,26 +30,22 @@ func NewClient(secretKey string) *Client {
 // paymentMethodID is the Stripe payment method ID (pm_...) provided by the borrower.
 // Returns the PaymentIntent ID (pi_...) and client_secret needed by the frontend for 3DS.
 func (c *Client) AuthorizeDeposit(amountCents int64, currency string, paymentMethodID string) (piID string, clientSecret string, err error) {
-	params := &stripe.PaymentIntentParams{
-		Amount:        stripe.Int64(amountCents),
-		Currency:      stripe.String(currency),
-		PaymentMethod: stripe.String(paymentMethodID),
-		CaptureMethod: stripe.String(string(stripe.PaymentIntentCaptureMethodManual)),
-		Confirm:       stripe.Bool(true),
-		AutomaticPaymentMethods: &stripe.PaymentIntentAutomaticPaymentMethodsParams{
-			Enabled:        stripe.Bool(true),
-			AllowRedirects: stripe.String("never"),
-		},
-	}
+    params := &stripe.PaymentIntentParams{
+        Amount:             stripe.Int64(amountCents),
+        Currency:           stripe.String(currency),
+        PaymentMethod:      stripe.String(paymentMethodID),
+        CaptureMethod:      stripe.String(string(stripe.PaymentIntentCaptureMethodManual)),
+        Confirm:            stripe.Bool(true),
+        PaymentMethodTypes: []*string{stripe.String("card")},
+    }
 
-	pi, err := paymentintent.New(params)
-	if err != nil {
-		return "", "", fmt.Errorf("stripe: failed to authorize deposit: %w", err)
-	}
+    pi, err := paymentintent.New(params)
+    if err != nil {
+        return "", "", fmt.Errorf("stripe: failed to authorize deposit: %w", err)
+    }
 
-	return pi.ID, pi.ClientSecret, nil
+    return pi.ID, pi.ClientSecret, nil
 }
-
 // CaptureDeposit captures a previously authorized PaymentIntent in full.
 // Call this when the handover QR is scanned successfully.
 // paymentIntentID is the pi_... value stored in the transactions table.

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -770,10 +770,12 @@ func TestConfirmReturn_InvalidCode_Returns422(t *testing.T) {
 
 func TestConfirmReturn_ValidCode_Returns200(t *testing.T) {
 	handoverAt := time.Now().Add(-24 * time.Hour)
+	startDate := handoverAt
+	endDate := time.Now()
 	router := setupRouter(&fakeRepository{
 		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
 		transactions: []transactions.Transaction{
-			{ID: "tx-1", Status: "handed_over", HandoverAt: &handoverAt},
+			{ID: "tx-1", Status: "handed_over", HandoverAt: &handoverAt, StartDate: &startDate, EndDate: &endDate},
 		},
 	})
 
@@ -848,10 +850,12 @@ func TestHandoverTransaction_Success(t *testing.T) {
 
 func TestReturnTransaction_Success(t *testing.T) {
 	handoverAt := time.Now().Add(-24 * time.Hour)
+	startDate := handoverAt
+	endDate := time.Now()
 	router := setupRouter(&fakeRepository{
 		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
 		transactions: []transactions.Transaction{
-			{ID: "tx-1", Status: "handed_over", StripePaymentIntentID: "", ListingID: "lst-1", HandoverAt: &handoverAt},
+			{ID: "tx-1", Status: "handed_over", StripePaymentIntentID: "", ListingID: "lst-1", HandoverAt: &handoverAt, StartDate: &startDate, EndDate: &endDate},
 		},
 	})
 

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -173,7 +173,15 @@ func (s *Service) Return(ctx context.Context, transactionID string, depositAmoun
 		return 0, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
 	}
 
-	daysBorrowed := calcDaysBorrowed(*t.HandoverAt, time.Now())
+	effectiveStart := *t.StartDate
+	if t.HandoverAt != nil && t.HandoverAt.After(effectiveStart) {
+		effectiveStart = *t.HandoverAt
+	}
+	effectiveEnd := *t.EndDate
+	if now := time.Now(); now.After(effectiveEnd) {
+		effectiveEnd = now
+	}
+	daysBorrowed := calcDaysBorrowed(effectiveStart, effectiveEnd)
 	refundAmountCents := depositAmountCents * int64(96-daysBorrowed) / 100
 
 	// Stripe requires at least 1 cent for refunds.

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -185,8 +185,8 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			handoverAt := time.Now().UTC()
 			startDate := time.Now().UTC().AddDate(0, 0, -tc.days)
+			handoverAt := startDate // handover ocurrió cuando empezó el préstamo
 			endDate := time.Now().UTC()
 			repo := &fakeRepository{
 				transactions: []transactions.Transaction{
@@ -218,8 +218,8 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 
 func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 	deposit := int64(10000)
-	handoverAt := time.Now().UTC()
 	startDate := time.Now().UTC().AddDate(0, 0, -1)
+	handoverAt := startDate
 	endDate := time.Now().UTC()
 	repo := &fakeRepository{
 		transactions: []transactions.Transaction{
@@ -248,8 +248,8 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 
 func TestReturn_DaysClamped(t *testing.T) {
 	t.Run("same-day return clamps to 1", func(t *testing.T) {
-		handoverAt := time.Now().UTC()
 		startDate := time.Now().UTC()
+		handoverAt := startDate
 		endDate := time.Now().UTC()
 		repo := &fakeRepository{
 			transactions: []transactions.Transaction{
@@ -277,8 +277,8 @@ func TestReturn_DaysClamped(t *testing.T) {
 	})
 
 	t.Run("over-7-day return clamps to 7", func(t *testing.T) {
-		handoverAt := time.Now().UTC()
 		startDate := time.Now().UTC().AddDate(0, 0, -10)
+		handoverAt := startDate
 		endDate := time.Now().UTC()
 		repo := &fakeRepository{
 			transactions: []transactions.Transaction{

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -185,7 +185,9 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			handoverAt := time.Now().UTC().AddDate(0, 0, -tc.days)
+			handoverAt := time.Now().UTC()
+			startDate := time.Now().UTC().AddDate(0, 0, -tc.days)
+			endDate := time.Now().UTC()
 			repo := &fakeRepository{
 				transactions: []transactions.Transaction{
 					{
@@ -194,6 +196,8 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 						StripePaymentIntentID: "pi_fake",
 						ListingID:             "lst-1",
 						HandoverAt:            &handoverAt,
+						StartDate:             &startDate,
+						EndDate:               &endDate,
 					},
 				},
 			}
@@ -213,10 +217,10 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 }
 
 func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
-	// deposit is 10000; total charged would be 10200 (deposit + €2 fee).
-	// Only the deposit (not the fee) should be passed to ReleaseDeposit.
 	deposit := int64(10000)
-	handoverAt := time.Now().UTC().AddDate(0, 0, -1)
+	handoverAt := time.Now().UTC()
+	startDate := time.Now().UTC().AddDate(0, 0, -1)
+	endDate := time.Now().UTC()
 	repo := &fakeRepository{
 		transactions: []transactions.Transaction{
 			{
@@ -225,6 +229,8 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 				StripePaymentIntentID: "pi_fake",
 				ListingID:             "lst-1",
 				HandoverAt:            &handoverAt,
+				StartDate:             &startDate,
+				EndDate:               &endDate,
 			},
 		},
 	}
@@ -235,7 +241,6 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 	_, err := svc.Return(context.Background(), "tx-1", deposit)
 
 	assert.NoError(t, err)
-	// refundAmount must be strictly less than the deposit (fee not refunded, and lender keeps a share)
 	assert.Less(t, fs.releasedAmount, deposit)
 	assert.Equal(t, "lst-1", lsvc.updatedListingID)
 	assert.Equal(t, "available", lsvc.updatedStatus)
@@ -243,7 +248,9 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 
 func TestReturn_DaysClamped(t *testing.T) {
 	t.Run("same-day return clamps to 1", func(t *testing.T) {
-		handoverAt := time.Now().UTC() // same day
+		handoverAt := time.Now().UTC()
+		startDate := time.Now().UTC()
+		endDate := time.Now().UTC()
 		repo := &fakeRepository{
 			transactions: []transactions.Transaction{
 				{
@@ -252,6 +259,8 @@ func TestReturn_DaysClamped(t *testing.T) {
 					StripePaymentIntentID: "pi_fake",
 					ListingID:             "lst-1",
 					HandoverAt:            &handoverAt,
+					StartDate:             &startDate,
+					EndDate:               &endDate,
 				},
 			},
 		}
@@ -268,7 +277,9 @@ func TestReturn_DaysClamped(t *testing.T) {
 	})
 
 	t.Run("over-7-day return clamps to 7", func(t *testing.T) {
-		handoverAt := time.Now().UTC().AddDate(0, 0, -10)
+		handoverAt := time.Now().UTC()
+		startDate := time.Now().UTC().AddDate(0, 0, -10)
+		endDate := time.Now().UTC()
 		repo := &fakeRepository{
 			transactions: []transactions.Transaction{
 				{
@@ -277,6 +288,8 @@ func TestReturn_DaysClamped(t *testing.T) {
 					StripePaymentIntentID: "pi_fake",
 					ListingID:             "lst-1",
 					HandoverAt:            &handoverAt,
+					StartDate:             &startDate,
+					EndDate:               &endDate,
 				},
 			},
 		}

--- a/frontend/src/__tests__/ReserveModal.test.tsx
+++ b/frontend/src/__tests__/ReserveModal.test.tsx
@@ -80,9 +80,9 @@ describe('ReserveModal', () => {
             expect(screen.getByRole('button', { name: /confirmar reserva/i })).not.toBeDisabled();
         });
 
-        // 4 días × 20 € = 80 €
-        expect(screen.getByText(/4 días × 20 €/)).toBeInTheDocument();
-        expect(screen.getByText('80 €')).toBeInTheDocument();
+
+        expect(screen.getByText(/Total a pagar/i)).toBeInTheDocument();
+        expect(screen.getByText('22.00 €')).toBeInTheDocument();
     });
 
     it('carga las fechas bloqueadas al montar', async () => {

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -27,7 +27,7 @@ export default function PaymentModal({
     const end = new Date(endDate);
     const diffMs = end.getTime() - start.getTime();
     const days = Math.max(1, Math.round(diffMs / 86400000)) || 1; // Default to 1 day if invalid
-    const depositCents = Math.round(days * Number(depositAmount) * 100) || 0;
+    const depositCents = Math.round(Number(depositAmount) * 100) || 0;
     const totalEuros = (depositCents + 200) / 100;
 
     async function handlePay() {

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -14,19 +14,12 @@ interface Props {
 export default function PaymentModal({
     transactionId,
     depositAmount,
-    startDate,
-    endDate,
     onClose,
     onSuccess
 }: Props) {
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const paymentFormRef = useRef<PaymentFormHandle>(null);
-
-    const start = new Date(startDate);
-    const end = new Date(endDate);
-    const diffMs = end.getTime() - start.getTime();
-    const days = Math.max(1, Math.round(diffMs / 86400000)) || 1; // Default to 1 day if invalid
     const depositCents = Math.round(Number(depositAmount) * 100) || 0;
     const totalEuros = (depositCents + 200) / 100;
 

--- a/frontend/src/components/ReserveModal.tsx
+++ b/frontend/src/components/ReserveModal.tsx
@@ -37,7 +37,7 @@ export default function ReserveModal({ listingId, depositAmount, onClose, onSucc
     });
 
     const days = range ? Math.round((range.to.getTime() - range.from.getTime()) / 86400000) : 0;
-    const total = days * depositAmount;
+    const total = depositAmount;
 
     function handleRangeSelect(r: DayPickerRange | undefined) {
         if (!r?.from || !r?.to) {
@@ -55,7 +55,7 @@ export default function ReserveModal({ listingId, depositAmount, onClose, onSucc
 
     async function handleConfirm() {
         if (!range) return;
-        
+
         // Función auxiliar para obtener YYYY-MM-DD en hora local
         const formatDateLocal = (date: Date) => {
             const year = date.getFullYear();
@@ -110,7 +110,7 @@ export default function ReserveModal({ listingId, depositAmount, onClose, onSucc
                 {days > 0 && (
                     <div className="mt-4 p-3 bg-[var(--surface-strong)] rounded-2xl text-sm">
                         <div className="flex justify-between">
-                            <span className="text-[var(--muted)]">{days} días × {depositAmount} €</span>
+                            <span className="text-[var(--muted)]">{days} días</span>
                             <span className="font-semibold">{total} €</span>
                         </div>
                     </div>

--- a/frontend/src/components/ReserveModal.tsx
+++ b/frontend/src/components/ReserveModal.tsx
@@ -107,14 +107,31 @@ export default function ReserveModal({ listingId, depositAmount, onClose, onSucc
                     numberOfMonths={1}
                 />
 
-                {days > 0 && (
-                    <div className="mt-4 p-3 bg-[var(--surface-strong)] rounded-2xl text-sm">
-                        <div className="flex justify-between">
-                            <span className="text-[var(--muted)]">{days} días</span>
-                            <span className="font-semibold">{total} €</span>
+                {days > 0 && (() => {
+                    const refundPct = Math.max(89, 96 - days);
+                    const refundAmount = ((depositAmount * refundPct) / 100).toFixed(2);
+                    return (
+                        <div className="mt-4 p-3 bg-[var(--surface-strong)] rounded-2xl text-sm flex flex-col gap-2">
+                            <div className="flex justify-between">
+                                <span className="text-[var(--muted)]">Fianza</span>
+                                <span className="font-semibold">{depositAmount} €</span>
+                            </div>
+                            <div className="flex justify-between text-xs text-[var(--muted)]">
+                                <span>Gastos de gestión</span>
+                                <span>2.00 €</span>
+                            </div>
+                            <div className="h-px bg-[var(--border)]" />
+                            <div className="flex justify-between font-semibold">
+                                <span>Total a pagar ({days} días)</span>
+                                <span>{(depositAmount + 2).toFixed(2)} €</span>
+                            </div>
+                            <div className="flex justify-between text-xs text-green-600">
+                                <span>Devolución estimada ({refundPct}%)</span>
+                                <span>+{refundAmount} €</span>
+                            </div>
                         </div>
-                    </div>
-                )}
+                    );
+                })()}
 
                 <button
                     onClick={handleConfirm}

--- a/frontend/src/components/ReserveModal.tsx
+++ b/frontend/src/components/ReserveModal.tsx
@@ -37,7 +37,6 @@ export default function ReserveModal({ listingId, depositAmount, onClose, onSucc
     });
 
     const days = range ? Math.round((range.to.getTime() - range.from.getTime()) / 86400000) : 0;
-    const total = depositAmount;
 
     function handleRangeSelect(r: DayPickerRange | undefined) {
         if (!r?.from || !r?.to) {

--- a/frontend/src/components/chats/TransactionInfoPanel.tsx
+++ b/frontend/src/components/chats/TransactionInfoPanel.tsx
@@ -27,8 +27,8 @@ export default function TransactionInfoPanel({
             : null;
     const totalEuros = transaction.total_charged_cents
         ? (transaction.total_charged_cents / 100).toFixed(2)
-        : days
-            ? (days * listing.deposit_amount + 2).toFixed(2)
+        : listing.deposit_amount
+            ? (listing.deposit_amount + 2).toFixed(2)
             : '—';
 
     const formatDate = (d: Date) =>


### PR DESCRIPTION
`end_date` with effective start/end logic (takes the latest between handover/start and end/now)

### Frontend
- `PaymentModal.tsx`: removed `days *` multiplier — deposit is now fixed regardless of days
- `ReserveModal.tsx`: removed `days *` multiplier, updated UI to show fixed deposit, management fee (2€), total to pay and estimated refund percentage
- `TransactionInfoPanel.tsx`: fixed `totalEuros` calculation to use fixed deposit instead of `days * deposit`