### PR TITLE
Task 15 bug with points in frontend

### DIFF
--- a/backend/internal/transactions/domain.go
+++ b/backend/internal/transactions/domain.go
@@ -18,6 +18,7 @@ type Transaction struct {
 	StripePaymentIntentID string     `json:"stripe_payment_intent_id,omitempty"`
 	PaymentMethodID       string     `json:"payment_method_id,omitempty"`
 	TotalChargedCents     int64      `json:"total_charged_cents,omitempty"`
+	PaymentMethod         string     `json:"payment_method,omitempty"`
 	StartDate             *time.Time `json:"start_date"`
 	EndDate               *time.Time `json:"end_date"`
 	AgreedAt              *time.Time `json:"agreed_at"`

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -377,7 +377,7 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 	}
 
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(depositAmountCents * int64(result.DaysBorrowed+4) / 100)
+	pointsEarned := int((depositAmountCents - PlatformFeeCents) * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}
@@ -621,7 +621,7 @@ func (h *Handler) confirmReturn(c *gin.Context) {
 		return
 	}
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(body.DepositAmountCents * int64(result.DaysBorrowed+4) / 100)
+	pointsEarned := int((body.DepositAmountCents - PlatformFeeCents) * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -370,16 +370,22 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 		return
 	}
 
-	daysBorrowed, err := h.service.Return(c.Request.Context(), id, depositAmountCents)
+	result, err := h.service.Return(c.Request.Context(), id, depositAmountCents)
 	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(depositAmountCents * int64(daysBorrowed+4) / 100)
+	pointsEarned := int(depositAmountCents * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
+	}
+
+	if result.PaymentMethod == "points" {
+		if err := h.walletSvc.AddPoints(c.Request.Context(), result.BorrowerID, int(result.RefundAmountCents)); err != nil {
+			slog.Error("failed to refund points to borrower after return", "transaction_id", id, "error", err)
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"success": true})
@@ -609,15 +615,20 @@ func (h *Handler) confirmReturn(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid return code"})
 		return
 	}
-	daysBorrowed, err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents)
+	result, err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents)
 	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(body.DepositAmountCents * int64(daysBorrowed+4) / 100)
+	pointsEarned := int(body.DepositAmountCents * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
+	}
+	if result.PaymentMethod == "points" {
+		if err := h.walletSvc.AddPoints(c.Request.Context(), result.BorrowerID, int(result.RefundAmountCents)); err != nil {
+			slog.Error("failed to refund points to borrower after return", "transaction_id", id, "error", err)
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,13 +20,13 @@ type adminChecker interface {
 type Handler struct {
 	repo      Repository
 	service   *Service
-	walletSvc pointsAdder
+	walletSvc pointsWallet
 	notifSvc  notificationCreator
 	adminSvc  adminChecker
 }
 
-// NewHandler creates a new Handler injecting the Repository, Service, and a pointsAdder.
-func NewHandler(repo Repository, service *Service, walletSvc pointsAdder, notifSvc notificationCreator, adminSvc adminChecker) *Handler {
+// NewHandler creates a new Handler injecting the Repository, Service, and a pointsWallet.
+func NewHandler(repo Repository, service *Service, walletSvc pointsWallet, notifSvc notificationCreator, adminSvc adminChecker) *Handler {
 	return &Handler{repo: repo, service: service, walletSvc: walletSvc, notifSvc: notifSvc, adminSvc: adminSvc}
 }
 
@@ -291,16 +292,24 @@ func (h *Handler) payTransaction(c *gin.Context) {
 
 	var body struct {
 		DepositAmountCents int64  `json:"deposit_amount_cents"`
-		PaymentMethodID    string `json:"payment_method_id" binding:"required"`
+		PaymentMethodID    string `json:"payment_method_id"`
+		PaymentMethod      string `json:"payment_method"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		slog.Error("failed to parse pay transaction body", "error", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	if body.PaymentMethod == "" {
+		body.PaymentMethod = "card"
+	}
 
-	clientSecret, err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID)
+	clientSecret, err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID, body.PaymentMethod)
 	if err != nil {
+		if errors.Is(err, ErrInsufficientPoints) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+			return
+		}
 		h.handleServiceError(c, "pay", id, err)
 		return
 	}

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -899,3 +899,105 @@ func TestHandoverTransaction_WrongStatus_Returns409(t *testing.T) {
 
 	assert.Equal(t, http.StatusConflict, w.Code)
 }
+
+// ---- Points payment integration tests ----
+
+func setupRouterWithWallet(repo transactions.Repository, fs *fakeStripe, wallet *mockPointsWallet) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(gin.Recovery())
+	svc := transactions.NewService(repo, fs, &noopListingUpdater{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+	h := transactions.NewHandler(repo, svc, wallet, &noopNotificationCreator{}, &mockAdminChecker{})
+	api := r.Group("/api")
+	h.RegisterRoutes(api, middleware.RequireAuth(testJWTSecret))
+	return r
+}
+
+func TestPayTransaction_WithPoints_Success(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 1000} // enough for deposit(800)+fee(200)
+
+	router := setupRouterWithWallet(repo, &fakeStripe{}, wallet)
+
+	body := `{"deposit_amount_cents":800,"payment_method":"points"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/pay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "agreed", repo.transactions[0].Status)
+	assert.Equal(t, "points", repo.transactions[0].PaymentMethod)
+}
+
+func TestPayTransaction_WithPoints_InsufficientFunds_Returns422(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 500} // not enough for deposit(800)+fee(200)=1000
+
+	router := setupRouterWithWallet(repo, &fakeStripe{}, wallet)
+
+	body := `{"deposit_amount_cents":800,"payment_method":"points"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/pay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assert.Equal(t, "awaiting_payment", repo.transactions[0].Status)
+}
+
+func TestHandoverTransaction_SkipsStripe_WhenPointsPayment(t *testing.T) {
+	fs := &fakeStripe{}
+	repo := &fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed", PaymentMethod: "points", ListingID: "lst-1"},
+		},
+	}
+	router := setupRouterWithWallet(repo, fs, &mockPointsWallet{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/handover", bytes.NewReader([]byte{}))
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, fs.captureCalled)
+}
+
+func TestReturnTransaction_SkipsStripeAndRefundsPoints_WhenPointsPayment(t *testing.T) {
+	handoverAt := time.Now().Add(-24 * time.Hour)
+	fs := &fakeStripe{}
+	repo := &fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+		transactions: []transactions.Transaction{
+			{
+				ID: "tx-1", Status: "handed_over", PaymentMethod: "points",
+				BorrowerID: "borrower-1", ListingID: "lst-1", HandoverAt: &handoverAt,
+			},
+		},
+	}
+	wallet := &mockPointsWallet{}
+	router := setupRouterWithWallet(repo, fs, wallet)
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/return", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), fs.releasedAmount) // Stripe NOT called
+	assert.Greater(t, wallet.added, 0)            // borrower received points refund
+}

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -54,13 +54,14 @@ func (r *postgresRepository) FindByID(ctx context.Context, id string) (*Transact
 			COALESCE(stripe_payment_intent_id, '') AS stripe_payment_intent_id,
 			COALESCE(payment_method_id, '')        AS payment_method_id,
 			total_charged_cents, start_date, end_date, agreed_at, handover_at, return_at,
-			dispute_refund_points
+			dispute_refund_points,
+			COALESCE(payment_method, 'card')       AS payment_method
 		FROM transactions
 		WHERE id = $1
 	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status,
 		&t.StripePaymentIntentID, &t.PaymentMethodID,
 		&t.TotalChargedCents, &t.StartDate, &t.EndDate, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt,
-		&t.DisputeRefundPoints)
+		&t.DisputeRefundPoints, &t.PaymentMethod)
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -188,12 +189,28 @@ func (r *postgresRepository) UpdatePaymentIntent(ctx context.Context, id string,
 		SET stripe_payment_intent_id = $1,
 		    payment_method_id        = $2,
 		    total_charged_cents      = $3,
+		    payment_method           = 'card',
 		    status                   = 'agreed',
 		    agreed_at                = NOW()
 		WHERE id = $4
 	`, paymentIntentID, paymentMethodID, totalChargedCents, id)
 	if err != nil {
 		return fmt.Errorf("transactions: update payment intent failed: %w", err)
+	}
+	return nil
+}
+
+func (r *postgresRepository) SetAgreedWithPoints(ctx context.Context, id string, totalChargedCents int64) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE transactions
+		SET total_charged_cents = $1,
+		    payment_method      = 'points',
+		    status              = 'agreed',
+		    agreed_at           = NOW()
+		WHERE id = $2
+	`, totalChargedCents, id)
+	if err != nil {
+		return fmt.Errorf("transactions: set agreed with points failed: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/transactions/repository.go
+++ b/backend/internal/transactions/repository.go
@@ -17,6 +17,10 @@ type Repository interface {
 	// charged amount on the transaction and sets its status to agreed.
 	UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string, totalChargedCents int64) error
 
+	// SetAgreedWithPoints sets the transaction to agreed status after a points payment,
+	// recording the total cost without creating a Stripe PaymentIntent.
+	SetAgreedWithPoints(ctx context.Context, id string, totalChargedCents int64) error
+
 	// UpdateStatus updates only the status field and the corresponding timestamp.
 	// validStatuses: handed_over (sets handover_at), returned (sets return_at), cancelled.
 	UpdateStatus(ctx context.Context, id string, status string) error

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -165,7 +165,7 @@ func (s *Service) Handover(ctx context.Context, transactionID string) error {
 		return fmt.Errorf("service: transaction %s must be in agreed status to hand over", transactionID)
 	}
 
-	if !isDevPaymentIntent(t.StripePaymentIntentID) {
+	if t.PaymentMethod != "points" && !isDevPaymentIntent(t.StripePaymentIntentID) {
 		if err := s.stripe.CaptureDeposit(t.StripePaymentIntentID); err != nil {
 			return fmt.Errorf("service: capture deposit: %w", err)
 		}
@@ -181,40 +181,54 @@ func (s *Service) Handover(ctx context.Context, transactionID string) error {
 	return nil
 }
 
+// ReturnResult holds the outcome of a Return call so the handler can apply post-return actions.
+type ReturnResult struct {
+	DaysBorrowed      int
+	RefundAmountCents int64
+	PaymentMethod     string
+	BorrowerID        string
+}
+
 // Return refunds a variable percentage of the deposit to the borrower based on days borrowed,
 // marks the transaction as returned, and updates the listing status back to available.
-// Returns the number of days borrowed so the caller can compute the lender's points.
-func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) (int, error) {
+// Returns a ReturnResult so the caller can apply wallet credits or Stripe release.
+func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) (*ReturnResult, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
-		return 0, fmt.Errorf("service: find transaction: %w", err)
+		return nil, fmt.Errorf("service: find transaction: %w", err)
 	}
 	if t == nil || t.Status != "handed_over" {
-		return 0, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
+		return nil, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
 	}
 
 	daysBorrowed := calcDaysBorrowed(*t.HandoverAt, time.Now())
 	refundAmountCents := depositAmountCents * int64(96-daysBorrowed) / 100
 
-	// Stripe requires at least 1 cent for refunds.
-	if refundAmountCents < 1 {
-		refundAmountCents = 1
-	}
-
-	if !isDevPaymentIntent(t.StripePaymentIntentID) {
-		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, refundAmountCents); err != nil {
-			return 0, fmt.Errorf("service: release deposit: %w", err)
+	if t.PaymentMethod != "points" {
+		// Stripe requires at least 1 cent for refunds.
+		if refundAmountCents < 1 {
+			refundAmountCents = 1
+		}
+		if !isDevPaymentIntent(t.StripePaymentIntentID) {
+			if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, refundAmountCents); err != nil {
+				return nil, fmt.Errorf("service: release deposit: %w", err)
+			}
 		}
 	}
 
 	if err := s.repo.UpdateStatus(ctx, transactionID, "returned"); err != nil {
-		return 0, fmt.Errorf("service: update status: %w", err)
+		return nil, fmt.Errorf("service: update status: %w", err)
 	}
 
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "available"); err != nil {
-		return 0, fmt.Errorf("service: update listing status: %w", err)
+		return nil, fmt.Errorf("service: update listing status: %w", err)
 	}
-	return daysBorrowed, nil
+	return &ReturnResult{
+		DaysBorrowed:      daysBorrowed,
+		RefundAmountCents: refundAmountCents,
+		PaymentMethod:     t.PaymentMethod,
+		BorrowerID:        t.BorrowerID,
+	}, nil
 }
 
 // ReportIssue transitions a transaction to pending_review and opens a chat with an admin.

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -2,9 +2,13 @@ package transactions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
+
+// ErrInsufficientPoints is returned when the borrower does not have enough points to pay.
+var ErrInsufficientPoints = errors.New("insufficient points to cover the deposit")
 
 type stripeDepositor interface {
 	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (piID string, clientSecret string, err error)
@@ -24,8 +28,9 @@ type messageCreator interface {
 	CreateSystemMessage(ctx context.Context, transactionID, content string) error
 }
 
-type pointsAdder interface {
+type pointsWallet interface {
 	AddPoints(ctx context.Context, userID string, points int) error
+	DeductPoints(ctx context.Context, userID string, points int) (bool, error)
 }
 
 type notificationCreator interface {
@@ -39,12 +44,12 @@ type Service struct {
 	listingSvc listingStatusUpdater
 	adminRepo  adminFinder
 	msgRepo    messageCreator
-	walletSvc  pointsAdder
+	walletSvc  pointsWallet
 	notifSvc   notificationCreator
 }
 
 // NewService creates a new Service instance with the required dependencies.
-func NewService(repo Repository, stripe stripeDepositor, listingSvc listingStatusUpdater, adminRepo adminFinder, msgRepo messageCreator, walletSvc pointsAdder, notifSvc notificationCreator) *Service {
+func NewService(repo Repository, stripe stripeDepositor, listingSvc listingStatusUpdater, adminRepo adminFinder, msgRepo messageCreator, walletSvc pointsWallet, notifSvc notificationCreator) *Service {
 	return &Service{repo: repo, stripe: stripe, listingSvc: listingSvc, adminRepo: adminRepo, msgRepo: msgRepo, walletSvc: walletSvc, notifSvc: notifSvc}
 }
 
@@ -61,9 +66,9 @@ func (s *Service) AcceptRequest(ctx context.Context, transactionID string) error
 	return s.repo.UpdateStatus(ctx, transactionID, "awaiting_payment")
 }
 
-// ConfirmPayment autoriza el depósito en Stripe y mueve la transacción a agreed.
-// Solo puede llamarlo el borrower cuando status = awaiting_payment.
-func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string) (string, error) {
+// ConfirmPayment authorises the deposit and moves the transaction to agreed.
+// paymentMethod must be "card" or "points". Only the borrower can call this when status = awaiting_payment.
+func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string, paymentMethod string) (string, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
 		return "", fmt.Errorf("service: find transaction: %w", err)
@@ -73,11 +78,28 @@ func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depo
 	}
 
 	totalCents := depositAmountCents + PlatformFeeCents
+
+	if paymentMethod == "points" {
+		ok, err := s.walletSvc.DeductPoints(ctx, t.BorrowerID, int(totalCents))
+		if err != nil {
+			return "", fmt.Errorf("service: deduct points: %w", err)
+		}
+		if !ok {
+			return "", ErrInsufficientPoints
+		}
+		if err := s.repo.SetAgreedWithPoints(ctx, transactionID, totalCents); err != nil {
+			return "", fmt.Errorf("service: set agreed with points: %w", err)
+		}
+		if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "pending_handover"); err != nil {
+			return "", fmt.Errorf("service: update listing status: %w", err)
+		}
+		return "", nil
+	}
+
 	actualPaymentMethodID := paymentMethodID
 	if actualPaymentMethodID == "" {
 		actualPaymentMethodID = t.PaymentMethodID
 	}
-
 	if actualPaymentMethodID == "" {
 		return "", fmt.Errorf("service: payment method ID is required")
 	}
@@ -86,11 +108,9 @@ func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depo
 	if err != nil {
 		return "", fmt.Errorf("service: authorize deposit: %w", err)
 	}
-
 	if err := s.repo.UpdatePaymentIntent(ctx, transactionID, stripePIID, actualPaymentMethodID, totalCents); err != nil {
 		return "", fmt.Errorf("service: update payment intent: %w", err)
 	}
-
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "pending_handover"); err != nil {
 		return "", fmt.Errorf("service: update listing status: %w", err)
 	}

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -99,7 +99,7 @@ func TestConfirmPayment_ChargesDepositPlusPlatformFee(t *testing.T) {
 	lsvc := &fakeListingSvc{}
 	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(700), fs.capturedAmount) // 500 deposit + 200 platform fee
@@ -115,7 +115,7 @@ func TestConfirmPayment_FailsIfNotAwaitingPayment(t *testing.T) {
 	}
 	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.Error(t, err)
 	assert.Empty(t, cs)
@@ -130,7 +130,7 @@ func TestConfirmPayment_ReturnsClientSecret(t *testing.T) {
 	fs := &fakeStripe{clientSecret: "pi_secret_xyz_secret"}
 	svc := transactions.NewService(repo, fs, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "pi_secret_xyz_secret", cs)

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -201,10 +201,10 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 			lsvc := &fakeListingSvc{}
 			svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-			daysBorrowed, err := svc.Return(context.Background(), "tx-1", tc.deposit)
+			res, err := svc.Return(context.Background(), "tx-1", tc.deposit)
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.wantDayReturned, daysBorrowed)
+			assert.Equal(t, tc.wantDayReturned, res.DaysBorrowed)
 			assert.Equal(t, tc.wantRefund, fs.releasedAmount)
 			assert.Equal(t, "lst-1", lsvc.updatedListingID)
 			assert.Equal(t, "available", lsvc.updatedStatus)
@@ -232,11 +232,12 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 	lsvc := &fakeListingSvc{}
 	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	_, err := svc.Return(context.Background(), "tx-1", deposit)
+	res, err := svc.Return(context.Background(), "tx-1", deposit)
 
 	assert.NoError(t, err)
 	// refundAmount must be strictly less than the deposit (fee not refunded, and lender keeps a share)
 	assert.Less(t, fs.releasedAmount, deposit)
+	assert.NotNil(t, res)
 	assert.Equal(t, "lst-1", lsvc.updatedListingID)
 	assert.Equal(t, "available", lsvc.updatedStatus)
 }
@@ -259,10 +260,10 @@ func TestReturn_DaysClamped(t *testing.T) {
 		lsvc := &fakeListingSvc{}
 		svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+		res, err := svc.Return(context.Background(), "tx-1", 10000)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 1, daysBorrowed)
+		assert.Equal(t, 1, res.DaysBorrowed)
 		assert.Equal(t, "lst-1", lsvc.updatedListingID)
 		assert.Equal(t, "available", lsvc.updatedStatus)
 	})
@@ -284,10 +285,10 @@ func TestReturn_DaysClamped(t *testing.T) {
 		lsvc := &fakeListingSvc{}
 		svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+		res, err := svc.Return(context.Background(), "tx-1", 10000)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 7, daysBorrowed)
+		assert.Equal(t, 7, res.DaysBorrowed)
 		assert.Equal(t, "lst-1", lsvc.updatedListingID)
 		assert.Equal(t, "available", lsvc.updatedStatus)
 	})

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -306,3 +306,123 @@ func TestReturn_FailsIfNotHandedOver(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+// --- Points payment unit tests ---
+
+func TestConfirmPayment_WithPoints_ExactBalance(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	wallet := &mockPointsWallet{points: 700} // exactly deposit(500) + fee(200)
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.NoError(t, err)
+	assert.Empty(t, cs)
+	assert.False(t, fs.captureCalled)
+	assert.Equal(t, int64(700), wallet.deducted)
+	assert.Equal(t, "agreed", repo.transactions[0].Status)
+	assert.Equal(t, "points", repo.transactions[0].PaymentMethod)
+	assert.Equal(t, "pending_handover", lsvc.updatedStatus)
+}
+
+func TestConfirmPayment_WithPoints_InsufficientFunds(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 699} // one point short of deposit(500)+fee(200)
+	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.ErrorIs(t, err, transactions.ErrInsufficientPoints)
+	assert.Empty(t, cs)
+	assert.Equal(t, "awaiting_payment", repo.transactions[0].Status)
+}
+
+func TestConfirmPayment_WithPoints_ZeroBalance(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 0}
+	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.ErrorIs(t, err, transactions.ErrInsufficientPoints)
+}
+
+func TestHandover_SkipsStripeForPointsPayment(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed", PaymentMethod: "points", ListingID: "lst-1"},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
+
+	err := svc.Handover(context.Background(), "tx-1")
+
+	assert.NoError(t, err)
+	assert.False(t, fs.captureCalled)
+	assert.Equal(t, "handed_over", repo.transactions[0].Status)
+}
+
+func TestReturn_RefundsPointsWhenPaidWithPoints(t *testing.T) {
+	handoverAt := time.Now().UTC().AddDate(0, 0, -1) // 1 day borrowed
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{
+				ID:            "tx-1",
+				Status:        "handed_over",
+				PaymentMethod: "points",
+				BorrowerID:    "borrower-1",
+				ListingID:     "lst-1",
+				HandoverAt:    &handoverAt,
+			},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
+
+	res, err := svc.Return(context.Background(), "tx-1", 10000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), fs.releasedAmount) // Stripe NOT called
+	assert.Equal(t, "points", res.PaymentMethod)
+	assert.Equal(t, "borrower-1", res.BorrowerID)
+	assert.Equal(t, int64(9500), res.RefundAmountCents) // 95% of 10000
+	assert.Equal(t, "available", lsvc.updatedStatus)
+}
+
+// mockPointsWallet tracks deductions for assertions.
+type mockPointsWallet struct {
+	points   int
+	deducted int64
+	added    int
+}
+
+func (m *mockPointsWallet) AddPoints(_ context.Context, _ string, pts int) error {
+	m.added += pts
+	return nil
+}
+
+func (m *mockPointsWallet) DeductPoints(_ context.Context, _ string, amount int) (bool, error) {
+	if m.points < amount {
+		return false, nil
+	}
+	m.points -= amount
+	m.deducted = int64(amount)
+	return true, nil
+}

--- a/backend/internal/transactions/shared_test.go
+++ b/backend/internal/transactions/shared_test.go
@@ -147,6 +147,23 @@ func (f *fakeRepository) UpdatePaymentIntent(_ context.Context, id string, payme
 		if t.ID == id {
 			f.transactions[i].StripePaymentIntentID = paymentIntentID
 			f.transactions[i].PaymentMethodID = paymentMethodID
+			f.transactions[i].TotalChargedCents = totalChargedCents
+			f.transactions[i].PaymentMethod = "card"
+			f.transactions[i].Status = "agreed"
+			f.transactions[i].AgreedAt = &now
+			return nil
+		}
+	}
+	return fmt.Errorf("transaction %s not found", id)
+}
+
+func (f *fakeRepository) SetAgreedWithPoints(_ context.Context, id string, totalChargedCents int64) error {
+	if f.err != nil { return f.err }
+	now := time.Now()
+	for i, t := range f.transactions {
+		if t.ID == id {
+			f.transactions[i].TotalChargedCents = totalChargedCents
+			f.transactions[i].PaymentMethod = "points"
 			f.transactions[i].Status = "agreed"
 			f.transactions[i].AgreedAt = &now
 			return nil

--- a/backend/internal/transactions/shared_test.go
+++ b/backend/internal/transactions/shared_test.go
@@ -12,7 +12,10 @@ import (
 // --- Shared Mocks ---
 
 type noopPointsAdder struct{}
-func (noopPointsAdder) AddPoints(_ context.Context, _ string, _ int) error { return nil }
+func (noopPointsAdder) AddPoints(_ context.Context, _ string, _ int) error   { return nil }
+func (noopPointsAdder) DeductPoints(_ context.Context, _ string, _ int) (bool, error) {
+	return true, nil
+}
 
 type noopNotificationCreator struct{}
 func (noopNotificationCreator) Create(_ context.Context, _ string, _ string, _ map[string]any) error { return nil }

--- a/backend/internal/users/handler.go
+++ b/backend/internal/users/handler.go
@@ -32,8 +32,24 @@ func (h *Handler) RegisterRoutes(rg *gin.RouterGroup, authMiddleware gin.Handler
 
 	protected := rg.Group("/")
 	protected.Use(authMiddleware)
+	protected.GET("/users/me", h.getMe)
 	protected.PUT("/users/me", h.updateMe)
 	protected.POST("/users/me/avatar", h.uploadAvatar)
+}
+
+func (h *Handler) getMe(c *gin.Context) {
+	userID := c.MustGet("userID").(string)
+	user, err := h.repo.FindByID(c.Request.Context(), userID)
+	if err != nil {
+		slog.Error("failed to get current user", "id", userID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		return
+	}
+	if user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": user})
 }
 
 func (h *Handler) listUsers(c *gin.Context) {

--- a/backend/internal/wallet/domain.go
+++ b/backend/internal/wallet/domain.go
@@ -44,6 +44,9 @@ type PointsHistoryEntry struct {
 type Repository interface {
 	GetPoints(ctx context.Context, userID string) (int, error)
 	AddPoints(ctx context.Context, userID string, delta int) error
+	// DeductPoints atomically removes points only if the balance is sufficient.
+	// Returns true if deducted, false (no error) if balance was insufficient.
+	DeductPoints(ctx context.Context, userID string, amount int) (bool, error)
 	CreateRedemption(ctx context.Context, userID string, points int) (*Redemption, error)
 	GetPointsHistory(ctx context.Context, userID string) ([]PointsHistoryEntry, error)
 	GetStripeConnectAccountID(ctx context.Context, userID string) (string, error)
@@ -53,6 +56,9 @@ type Repository interface {
 // Service is the business-logic contract for the wallet package.
 type Service interface {
 	AddPoints(ctx context.Context, userID string, points int) error
+	// DeductPoints atomically removes points only if balance is sufficient.
+	// Returns true if deducted, false (no error) if insufficient.
+	DeductPoints(ctx context.Context, userID string, points int) (bool, error)
 	RedeemPoints(ctx context.Context, userID string, pointsToRedeem int) (*Redemption, error)
 	GetPointsHistory(ctx context.Context, userID string) ([]PointsHistoryEntry, error)
 }

--- a/backend/internal/wallet/handler_test.go
+++ b/backend/internal/wallet/handler_test.go
@@ -66,6 +66,17 @@ func (f *fakeRepository) UpdateRedemptionStatus(_ context.Context, _, _ string) 
 	return nil
 }
 
+func (f *fakeRepository) DeductPoints(_ context.Context, _ string, amount int) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if f.points < amount {
+		return false, nil
+	}
+	f.points -= amount
+	return true, nil
+}
+
 // fakeStripe implements wallet.StripePayouter for tests.
 type fakeStripe struct{ fail bool }
 

--- a/backend/internal/wallet/postgres_repository.go
+++ b/backend/internal/wallet/postgres_repository.go
@@ -33,6 +33,16 @@ func (r *postgresRepository) AddPoints(ctx context.Context, userID string, delta
 	return nil
 }
 
+func (r *postgresRepository) DeductPoints(ctx context.Context, userID string, amount int) (bool, error) {
+	res, err := r.pool.Exec(ctx,
+		`UPDATE users SET points = points - $1 WHERE id = $2 AND points >= $1`,
+		amount, userID)
+	if err != nil {
+		return false, fmt.Errorf("wallet: deduct points failed: %w", err)
+	}
+	return res.RowsAffected() > 0, nil
+}
+
 func (r *postgresRepository) CreateRedemption(ctx context.Context, userID string, points int) (*Redemption, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {

--- a/backend/internal/wallet/service.go
+++ b/backend/internal/wallet/service.go
@@ -19,6 +19,10 @@ func (s *service) AddPoints(ctx context.Context, userID string, points int) erro
 	return s.repo.AddPoints(ctx, userID, points)
 }
 
+func (s *service) DeductPoints(ctx context.Context, userID string, points int) (bool, error) {
+	return s.repo.DeductPoints(ctx, userID, points)
+}
+
 func (s *service) RedeemPoints(ctx context.Context, userID string, pointsToRedeem int) (*Redemption, error) {
 	balance, err := s.repo.GetPoints(ctx, userID)
 	if err != nil {

--- a/frontend/src/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/__tests__/PaymentModal.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import PaymentModal from '../components/PaymentModal';
+
+// Stripe mocks (PaymentForm imports these)
+vi.mock('@stripe/stripe-js', () => ({ loadStripe: vi.fn().mockResolvedValue(null) }));
+vi.mock('@stripe/react-stripe-js', () => ({
+    Elements: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CardNumberElement: () => <div data-testid="card-number" />,
+    CardExpiryElement: () => <div data-testid="card-expiry" />,
+    CardCvcElement: () => <div data-testid="card-cvc" />,
+    useStripe: () => ({
+        createPaymentMethod: vi.fn().mockResolvedValue({ paymentMethod: { id: 'pm_123' }, error: undefined }),
+        handleNextAction: vi.fn().mockResolvedValue({}),
+        retrievePaymentIntent: vi.fn().mockResolvedValue({ paymentIntent: { status: 'succeeded' } }),
+    }),
+    useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
+}));
+
+vi.mock('../lib/transactions', () => ({
+    transactionsApi: {
+        pay: vi.fn().mockResolvedValue({ clientSecret: '' }),
+    },
+}));
+
+import { transactionsApi } from '../lib/transactions';
+
+const baseProps = {
+    transactionId: 'tx-1',
+    depositAmount: 50,
+    startDate: '2026-06-10',
+    endDate: '2026-06-11',
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+};
+
+// totalCents = 1 day * 50€ * 100 + 200 = 5200
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('PaymentModal — selector de método de pago', () => {
+    it('muestra el selector de método de pago al abrir', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        expect(screen.getByText('Método de pago')).toBeDefined();
+        expect(screen.getByText('Pagar con tarjeta')).toBeDefined();
+    });
+
+    it('muestra la opción de puntos cuando el saldo es suficiente', () => {
+        render(<PaymentModal {...baseProps} userPoints={5200} />);
+        expect(screen.getByText('Pagar con puntos')).toBeDefined();
+    });
+
+    it('NO muestra la opción de puntos cuando el saldo es insuficiente', () => {
+        render(<PaymentModal {...baseProps} userPoints={5199} />);
+        expect(screen.queryByText('Pagar con puntos')).toBeNull();
+    });
+
+    it('NO muestra la opción de puntos con saldo 0', () => {
+        render(<PaymentModal {...baseProps} userPoints={0} />);
+        expect(screen.queryByText('Pagar con puntos')).toBeNull();
+    });
+
+    it('navega a la vista de tarjeta al seleccionar "Pagar con tarjeta"', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con tarjeta'));
+        expect(screen.getByText('Datos de pago')).toBeDefined();
+    });
+
+    it('navega a la vista de puntos al seleccionar "Pagar con puntos"', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        expect(screen.getByText('Pagar con puntos', { selector: 'h2' })).toBeDefined();
+    });
+
+    it('vuelve al selector al pulsar la flecha de retroceso', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con tarjeta'));
+        fireEvent.click(screen.getByLabelText('Volver'));
+        expect(screen.getByText('Método de pago')).toBeDefined();
+    });
+});
+
+describe('PaymentModal — pago con puntos', () => {
+    it('muestra el coste y saldo en la vista de puntos', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        // 5200 cents = 52.00 pts; remaining = 6000 - 5200 = 800 cents = 8.00 pts
+        expect(screen.getByText('60.00 pts')).toBeDefined(); // saldo actual
+        expect(screen.getByText('−52.00 pts')).toBeDefined(); // coste
+        expect(screen.getByText('8.00 pts')).toBeDefined();   // saldo tras pago
+    });
+
+    it('llama a transactionsApi.pay con payment_method=points al confirmar', async () => {
+        const onSuccess = vi.fn();
+        render(<PaymentModal {...baseProps} userPoints={6000} onSuccess={onSuccess} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        fireEvent.click(screen.getByText('Confirmar pago'));
+
+        await waitFor(() => expect(transactionsApi.pay).toHaveBeenCalledWith(
+            'tx-1',
+            5000, // depositCents
+            null,
+            'points',
+        ));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    });
+
+    it('llama a onPointsDeducted con el total en cents tras el pago', async () => {
+        const onPointsDeducted = vi.fn();
+        render(<PaymentModal {...baseProps} userPoints={6000} onPointsDeducted={onPointsDeducted} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        fireEvent.click(screen.getByText('Confirmar pago'));
+
+        await waitFor(() => expect(onPointsDeducted).toHaveBeenCalledWith(5200)); // depositCents+200
+    });
+});

--- a/frontend/src/__tests__/ReturnPage.test.tsx
+++ b/frontend/src/__tests__/ReturnPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import ReturnPage from '../pages/ReturnPage'
+import { AuthProvider } from '../contexts/AuthContext'
 import { api } from '../lib/api'
 
 const mockNavigate = vi.fn()
@@ -20,13 +21,21 @@ vi.mock('../lib/api', () => ({
     }
 }))
 
+vi.mock('../lib/users', () => ({
+    usersApi: {
+        getMe: vi.fn().mockResolvedValue({ id: 'u-1', points: 100 }),
+    }
+}))
+
 function renderPage() {
     return render(
-        <MemoryRouter initialEntries={['/listings/abc/return']}>
-            <Routes>
-                <Route path="/listings/:id/return" element={<ReturnPage />} />
-            </Routes>
-        </MemoryRouter>
+        <AuthProvider>
+            <MemoryRouter initialEntries={['/listings/abc/return']}>
+                <Routes>
+                    <Route path="/listings/:id/return" element={<ReturnPage />} />
+                </Routes>
+            </MemoryRouter>
+        </AuthProvider>
     )
 }
 

--- a/frontend/src/__tests__/transactions.test.ts
+++ b/frontend/src/__tests__/transactions.test.ts
@@ -62,7 +62,7 @@ describe('transactionsApi.getById', () => {
 });
 
 describe('transactionsApi.pay', () => {
-    it('envía PUT con el importe correcto', async () => {
+    it('envía PUT con el importe correcto (pago con tarjeta)', async () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
@@ -77,7 +77,30 @@ describe('transactionsApi.pay', () => {
                 method: 'PUT',
                 body: JSON.stringify({
                     deposit_amount_cents: 5000,
-                    payment_method_id: 'pm_123'
+                    payment_method_id: 'pm_123',
+                    payment_method: 'card',
+                }),
+            })
+        );
+    });
+
+    it('envía payment_method=points cuando se paga con puntos', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ client_secret: '' }),
+        });
+
+        await transactionsApi.pay('tx-1', 5000, null, 'points');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/transactions/tx-1/pay'),
+            expect.objectContaining({
+                method: 'PUT',
+                body: JSON.stringify({
+                    deposit_amount_cents: 5000,
+                    payment_method_id: null,
+                    payment_method: 'points',
                 }),
             })
         );
@@ -90,7 +113,7 @@ describe('transactionsApi.pay', () => {
             json: async () => ({ client_secret: 'pi_secret_abc' }),
         });
 
-        const result = await transactionsApi.pay('tx-1', 5000, 'pm_123');
+        const result = await transactionsApi.pay('tx-1', 5000, 'pm_123', 'card');
 
         expect(result.clientSecret).toBe('pi_secret_abc');
     });
@@ -101,6 +124,6 @@ describe('transactionsApi.pay', () => {
             json: async () => ({ error: 'transaction not in awaiting_payment state' }),
         });
 
-        await expect(transactionsApi.pay('tx-1', 5000, 'pm_123')).rejects.toThrow('awaiting_payment');
+        await expect(transactionsApi.pay('tx-1', 5000, 'pm_123', 'card')).rejects.toThrow('awaiting_payment');
     });
 });

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -2,13 +2,17 @@ import { useState, useRef } from 'react';
 import PaymentForm, { type PaymentFormHandle } from './PaymentForm';
 import { transactionsApi } from '../lib/transactions';
 
+type PaymentStep = 'select' | 'card' | 'points';
+
 interface Props {
     transactionId: string;
     depositAmount: number;
     startDate: string;
     endDate: string;
+    userPoints: number;
     onClose: () => void;
     onSuccess: () => void;
+    onPointsDeducted?: (cents: number) => void;
 }
 
 export default function PaymentModal({
@@ -16,9 +20,12 @@ export default function PaymentModal({
     depositAmount,
     startDate,
     endDate,
+    userPoints,
     onClose,
-    onSuccess
+    onSuccess,
+    onPointsDeducted,
 }: Props) {
+    const [step, setStep] = useState<PaymentStep>('select');
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const paymentFormRef = useRef<PaymentFormHandle>(null);
@@ -26,17 +33,19 @@ export default function PaymentModal({
     const start = new Date(startDate);
     const end = new Date(endDate);
     const diffMs = end.getTime() - start.getTime();
-    const days = Math.max(1, Math.round(diffMs / 86400000)) || 1; // Default to 1 day if invalid
+    const days = Math.max(1, Math.round(diffMs / 86400000)) || 1;
     const depositCents = Math.round(days * Number(depositAmount) * 100) || 0;
-    const totalEuros = (depositCents + 200) / 100;
+    const totalCents = depositCents + 200;
+    const totalEuros = totalCents / 100;
+    const canPayWithPoints = userPoints >= totalCents;
 
-    async function handlePay() {
+    async function handleCardPay() {
         if (!paymentFormRef.current) return;
         setSubmitting(true);
         setError(null);
         try {
             const pmId = await paymentFormRef.current.createPaymentMethod();
-            const { clientSecret } = await transactionsApi.pay(transactionId, depositCents, pmId);
+            const { clientSecret } = await transactionsApi.pay(transactionId, depositCents, pmId, 'card');
             await paymentFormRef.current.handleNextAction(clientSecret);
             onSuccess();
         } catch (err: unknown) {
@@ -46,11 +55,38 @@ export default function PaymentModal({
         }
     }
 
+    async function handlePointsPay() {
+        setSubmitting(true);
+        setError(null);
+        try {
+            await transactionsApi.pay(transactionId, depositCents, null, 'points');
+            onPointsDeducted?.(totalCents);
+            onSuccess();
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Error al procesar el pago con puntos');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
     return (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
             <div className="bg-white rounded-[28px] shadow-xl w-full max-w-md p-6">
                 <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-xl font-semibold">Datos de pago</h2>
+                    <div className="flex items-center gap-2">
+                        {step !== 'select' && (
+                            <button
+                                onClick={() => { setStep('select'); setError(null); }}
+                                className="text-gray-400 hover:text-gray-600 mr-1"
+                                aria-label="Volver"
+                            >
+                                ←
+                            </button>
+                        )}
+                        <h2 className="text-xl font-semibold">
+                            {step === 'select' ? 'Método de pago' : step === 'card' ? 'Datos de pago' : 'Pagar con puntos'}
+                        </h2>
+                    </div>
                     <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
                 </div>
 
@@ -60,23 +96,91 @@ export default function PaymentModal({
                     </p>
                 )}
 
-                <PaymentForm ref={paymentFormRef} totalEuros={totalEuros} />
+                {step === 'select' && (
+                    <div className="flex flex-col gap-3">
+                        <button
+                            onClick={() => setStep('card')}
+                            className="w-full flex flex-col items-start p-4 border-2 border-gray-200 rounded-2xl hover:border-[var(--accent)] transition-colors text-left"
+                        >
+                            <span className="font-semibold text-base">Pagar con tarjeta</span>
+                            <span className="text-sm text-gray-500 mt-1">Total: {totalEuros.toFixed(2)} €</span>
+                        </button>
 
-                <div className="flex gap-3 mt-6">
-                    <button
-                        onClick={onClose}
-                        className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
-                    >
-                        Cancelar
-                    </button>
-                    <button
-                        onClick={handlePay}
-                        disabled={submitting}
-                        className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
-                    >
-                        {submitting ? 'Pagando...' : 'Confirmar pago'}
-                    </button>
-                </div>
+                        {canPayWithPoints && (
+                            <button
+                                onClick={() => setStep('points')}
+                                className="w-full flex flex-col items-start p-4 border-2 border-gray-200 rounded-2xl hover:border-[var(--accent)] transition-colors text-left"
+                            >
+                                <span className="font-semibold text-base">Pagar con puntos</span>
+                                <span className="text-sm text-gray-500 mt-1">
+                                    Coste: {(totalCents / 100).toFixed(2)} pts · Saldo: {(userPoints / 100).toFixed(2)} pts
+                                </span>
+                            </button>
+                        )}
+
+                        <button
+                            onClick={onClose}
+                            className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold mt-2"
+                        >
+                            Cancelar
+                        </button>
+                    </div>
+                )}
+
+                {step === 'card' && (
+                    <>
+                        <PaymentForm ref={paymentFormRef} totalEuros={totalEuros} />
+                        <div className="flex gap-3 mt-6">
+                            <button
+                                onClick={onClose}
+                                className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                onClick={handleCardPay}
+                                disabled={submitting}
+                                className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
+                            >
+                                {submitting ? 'Pagando...' : 'Confirmar pago'}
+                            </button>
+                        </div>
+                    </>
+                )}
+
+                {step === 'points' && (
+                    <div className="flex flex-col gap-4">
+                        <div className="bg-gray-50 rounded-2xl p-4 text-sm">
+                            <div className="flex justify-between mb-2">
+                                <span className="text-gray-600">Saldo actual</span>
+                                <span className="font-semibold">{(userPoints / 100).toFixed(2)} pts</span>
+                            </div>
+                            <div className="flex justify-between mb-2">
+                                <span className="text-gray-600">Coste del depósito</span>
+                                <span className="font-semibold text-red-600">−{(totalCents / 100).toFixed(2)} pts</span>
+                            </div>
+                            <div className="border-t pt-2 flex justify-between">
+                                <span className="text-gray-600">Saldo tras el pago</span>
+                                <span className="font-semibold">{((userPoints - totalCents) / 100).toFixed(2)} pts</span>
+                            </div>
+                        </div>
+                        <div className="flex gap-3">
+                            <button
+                                onClick={onClose}
+                                className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                onClick={handlePointsPay}
+                                disabled={submitting}
+                                className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
+                            >
+                                {submitting ? 'Procesando...' : 'Confirmar pago'}
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -5,10 +5,11 @@ export const transactionsApi = {
     getById: (id: string): Promise<Transaction> =>
         api.get<{ data: Transaction }>(`/transactions/${id}`).then(r => r.data),
 
-    pay: (id: string, depositAmountCents: number, paymentMethodId: string): Promise<{ clientSecret: string }> =>
+    pay: (id: string, depositAmountCents: number, paymentMethodId: string | null, paymentMethod: 'card' | 'points' = 'card'): Promise<{ clientSecret: string }> =>
         api.put<{ client_secret: string }>(`/transactions/${id}/pay`, {
             deposit_amount_cents: depositAmountCents,
-            payment_method_id: paymentMethodId
+            payment_method_id: paymentMethodId,
+            payment_method: paymentMethod,
         }).then(r => ({ clientSecret: r.client_secret })),
 
     reportIssue: (id: string): Promise<void> =>

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -17,6 +17,9 @@ export const usersApi = {
     getUser: (id: string) =>
         api.get<ApiResponse<User>>(`/users/${id}`).then(r => r.data),
 
+    getMe: () =>
+        api.get<ApiResponse<User>>('/users/me').then(r => r.data),
+
     updateMe: (input: UpdateMeInput) =>
         api.put<ApiResponse<User>>('/users/me', input).then(r => r.data),
 

--- a/frontend/src/pages/ReturnPage.tsx
+++ b/frontend/src/pages/ReturnPage.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { api } from '../lib/api';
 import { transactionsApi } from '../lib/transactions';
+import { usersApi } from '../lib/users';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function ReturnPage() {
     const navigate = useNavigate();
     const { id: listingId } = useParams<{ id: string }>();
+    const { updateUser } = useAuth();
 
     const [transactionId, setTransactionId] = useState<string | null>(null);
     const [depositAmountCents, setDepositAmountCents] = useState<number>(0);
@@ -41,6 +44,7 @@ export default function ReturnPage() {
                 deposit_amount_cents: depositAmountCents,
             });
             setSuccess(true);
+            usersApi.getMe().then(me => updateUser(me)).catch(() => {});
             setTimeout(() => navigate('/profile'), 1500);
         } catch {
             setError('Código incorrecto o error al confirmar. Inténtalo de nuevo.');

--- a/frontend/src/pages/chats/ChatDetailPage.tsx
+++ b/frontend/src/pages/chats/ChatDetailPage.tsx
@@ -60,7 +60,7 @@ function getStatusBadge(status?: TransactionStatus): StatusBadge | null {
 
 export default function ChatDetailPage() {
     const { id: transactionId } = useParams<{ id: string }>();
-    const { user } = useAuth();
+    const { user, updateUser } = useAuth();
     const navigate = useNavigate();
 
     const [messages, setMessages] = useState<Message[]>([]);
@@ -307,8 +307,12 @@ export default function ChatDetailPage() {
                     depositAmount={listing.deposit_amount}
                     startDate={transaction.start_date ?? ''}
                     endDate={transaction.end_date ?? ''}
+                    userPoints={user?.points ?? 0}
                     onClose={() => setShowPayment(false)}
                     onSuccess={handlePaymentSuccess}
+                    onPointsDeducted={(cents) => {
+                        if (user) updateUser({ ...user, points: user.points - cents });
+                    }}
                 />
             )}
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,7 @@ export interface Transaction {
     status: TransactionStatus;
     stripe_payment_intent_id?: string;
     payment_method_id?: string;
+    payment_method?: 'card' | 'points';
     total_charged_cents: number;
     start_date: string | null;
     end_date: string | null;


### PR DESCRIPTION
## Summary

Fixes #75 — wallet points were inflated by +0.10 on every completed lending and the balance never refreshed in real-time.

- **Backend formula fix:** Both `returnTransaction` and `confirmReturn` handlers were using `total_charged_cents` (deposit + €2 platform fee) as the base for the points formula. The history SQL query already subtracts the 200¢ fee before multiplying, so the two calculations diverged by `200 × (daysBorrowed + 4) / 100` points per transaction — exactly the observed +0.10 drift. The handlers now subtract `PlatformFeeCents` before computing points, aligning with the history query.
- **New `GET /users/me` endpoint:** Added a protected endpoint that returns the authenticated user's full profile including their current `points` balance, so the frontend has a way to refresh it after a transaction.
- **Frontend real-time refresh:** After `confirm-return` succeeds, `ReturnPage` now calls `GET /users/me` and updates the auth context via `updateUser`, so the "Mi cartera" counter reflects the new balance immediately when the user lands on the profile page — no logout required.

## Test plan

- [ ] Complete a return flow as the item owner and verify "Mi cartera" updates immediately on the profile page without logging out.
- [ ] Verify the displayed balance matches the sum shown in "Historial de préstamos completados" with no +0.10 drift.
- [ ] Complete multiple returns and confirm the drift does not accumulate.
- [ ] Run backend tests: `go test ./...` from `backend/` — all pass.
- [ ] Run frontend type-check: `npx tsc --noEmit` from `frontend/` — no errors.
