### PR TITLE
Us 20 chats ux

### DIFF
--- a/backend/internal/messages/domain.go
+++ b/backend/internal/messages/domain.go
@@ -19,4 +19,5 @@ type Message struct {
 	ListingPhoto  string    `json:"listing_photo,omitempty"`
 	BorrowerID    string    `json:"borrower_id,omitempty"`
 	OwnerID       string    `json:"owner_id,omitempty"`
+	HasUnread     bool      `json:"has_unread,omitempty"`
 }

--- a/backend/internal/messages/handler.go
+++ b/backend/internal/messages/handler.go
@@ -163,15 +163,23 @@ func (h *Handler) createMessage(c *gin.Context) {
 	c.JSON(http.StatusCreated, gin.H{"data": created})
 }
 
-// markChatAsRead records that the authenticated user has read all messages in a transaction's chat.
-func (h *Handler) markChatAsRead(c *gin.Context) {
+func (h *Handler) requireUserID(c *gin.Context) (string, bool) {
 	userID, ok := c.Get("userID")
 	if !ok {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return "", false
+	}
+	return userID.(string), true
+}
+
+// markChatAsRead records that the authenticated user has read all messages in a transaction's chat.
+func (h *Handler) markChatAsRead(c *gin.Context) {
+	userID, ok := h.requireUserID(c)
+	if !ok {
 		return
 	}
 	transactionID := c.Param("id")
-	if err := h.repo.MarkAsRead(c.Request.Context(), userID.(string), transactionID); err != nil {
+	if err := h.repo.MarkAsRead(c.Request.Context(), userID, transactionID); err != nil {
 		slog.Error("failed to mark chat as read", "transaction_id", transactionID, "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 		return
@@ -181,12 +189,11 @@ func (h *Handler) markChatAsRead(c *gin.Context) {
 
 // unreadChatsCount returns the number of chats with unread messages for the authenticated user.
 func (h *Handler) unreadChatsCount(c *gin.Context) {
-	userID, ok := c.Get("userID")
+	userID, ok := h.requireUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	count, err := h.repo.CountUnread(c.Request.Context(), userID.(string))
+	count, err := h.repo.CountUnread(c.Request.Context(), userID)
 	if err != nil {
 		slog.Error("failed to count unread chats", "user_id", userID, "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
@@ -198,13 +205,12 @@ func (h *Handler) unreadChatsCount(c *gin.Context) {
 // listActiveChats returns the latest message per active transaction
 // where the authenticated user is a participant.
 func (h *Handler) listActiveChats(c *gin.Context) {
-	userID, ok := c.Get("userID")
+	userID, ok := h.requireUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
 
-	messages, err := h.repo.FindActiveByParticipant(c.Request.Context(), userID.(string))
+	messages, err := h.repo.FindActiveByParticipant(c.Request.Context(), userID)
 	if err != nil {
 		slog.Error("failed to list active chats", "user_id", userID, "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})

--- a/backend/internal/messages/handler.go
+++ b/backend/internal/messages/handler.go
@@ -32,7 +32,9 @@ func (h *Handler) RegisterRoutes(rg *gin.RouterGroup, authMiddleware gin.Handler
 	auth.GET("/transactions/:id/messages", h.listByTransaction)
 	auth.GET("/messages/:id", h.getMessage)
 	auth.POST("/transactions/:id/messages", h.createMessage)
+	auth.POST("/transactions/:id/messages/read", h.markChatAsRead)
 	auth.GET("/chats", h.listActiveChats)
+	auth.GET("/chats/unread-count", h.unreadChatsCount)
 	auth.POST("/transactions/:id/decision", h.decideTransaction)
 }
 
@@ -159,6 +161,38 @@ func (h *Handler) createMessage(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"data": created})
+}
+
+// markChatAsRead records that the authenticated user has read all messages in a transaction's chat.
+func (h *Handler) markChatAsRead(c *gin.Context) {
+	userID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	transactionID := c.Param("id")
+	if err := h.repo.MarkAsRead(c.Request.Context(), userID.(string), transactionID); err != nil {
+		slog.Error("failed to mark chat as read", "transaction_id", transactionID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// unreadChatsCount returns the number of chats with unread messages for the authenticated user.
+func (h *Handler) unreadChatsCount(c *gin.Context) {
+	userID, ok := c.Get("userID")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	count, err := h.repo.CountUnread(c.Request.Context(), userID.(string))
+	if err != nil {
+		slog.Error("failed to count unread chats", "user_id", userID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"count": count})
 }
 
 // listActiveChats returns the latest message per active transaction

--- a/backend/internal/messages/handler_test.go
+++ b/backend/internal/messages/handler_test.go
@@ -69,6 +69,17 @@ func (f *fakeRepository) FindActiveByParticipant(_ context.Context, _ string) ([
 	return f.messages, nil
 }
 
+func (f *fakeRepository) MarkAsRead(_ context.Context, _, _ string) error {
+	return f.err
+}
+
+func (f *fakeRepository) CountUnread(_ context.Context, _ string) (int, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return 0, nil
+}
+
 type fakeTxReader struct {
 	summary         *messages.TransactionSummary
 	err             error

--- a/backend/internal/messages/postgres_repository.go
+++ b/backend/internal/messages/postgres_repository.go
@@ -80,7 +80,7 @@ func (r *postgresRepository) Create(ctx context.Context, m Message) (*Message, e
 
 func (r *postgresRepository) FindActiveByParticipant(ctx context.Context, userID string) ([]Message, error) {
 	rows, err := r.pool.Query(ctx, `
-        SELECT id, transaction_id, sender_id, content, created_at, title, photo, status, borrower_id, owner_id
+        SELECT id, transaction_id, sender_id, content, created_at, title, photo, status, borrower_id, owner_id, has_unread
         FROM (
             SELECT DISTINCT ON (m.transaction_id)
                 m.id,
@@ -92,7 +92,17 @@ func (r *postgresRepository) FindActiveByParticipant(ctx context.Context, userID
                 COALESCE(l.photos->>0, '') AS photo,
                 t.status,
                 t.borrower_id,
-                l.owner_id
+                l.owner_id,
+                EXISTS (
+                    SELECT 1 FROM messages m2
+                    WHERE m2.transaction_id = m.transaction_id
+                      AND m2.sender_id != $1
+                      AND m2.created_at > COALESCE(
+                          (SELECT cr.last_read_at FROM chat_reads cr
+                           WHERE cr.user_id = $1 AND cr.transaction_id = m.transaction_id),
+                          '1970-01-01'::timestamptz
+                      )
+                ) AS has_unread
             FROM messages m
             JOIN transactions t ON t.id = m.transaction_id
             JOIN listings l     ON l.id = t.listing_id
@@ -114,7 +124,8 @@ func (r *postgresRepository) FindActiveByParticipant(ctx context.Context, userID
             COALESCE(l.photos->>0, '') AS photo,
             t.status,
             t.borrower_id,
-            l.owner_id
+            l.owner_id,
+            false AS has_unread
         FROM transactions t
         JOIN listings l ON l.id = t.listing_id
         JOIN users u    ON u.id = $1
@@ -135,7 +146,7 @@ func (r *postgresRepository) FindActiveByParticipant(ctx context.Context, userID
 		if err := rows.Scan(
 			&m.ID, &m.TransactionID, &m.SenderID, &m.Content, &m.CreatedAt,
 			&m.ListingTitle, &m.ListingPhoto, &m.Status,
-			&m.BorrowerID, &m.OwnerID,
+			&m.BorrowerID, &m.OwnerID, &m.HasUnread,
 		); err != nil {
 			return nil, fmt.Errorf("messages: scan failed: %w", err)
 		}
@@ -145,4 +156,38 @@ func (r *postgresRepository) FindActiveByParticipant(ctx context.Context, userID
 		return nil, fmt.Errorf("messages: iteration failed: %w", err)
 	}
 	return messages, nil
+}
+
+func (r *postgresRepository) MarkAsRead(ctx context.Context, userID, transactionID string) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO chat_reads (user_id, transaction_id, last_read_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (user_id, transaction_id) DO UPDATE SET last_read_at = NOW()
+	`, userID, transactionID)
+	if err != nil {
+		return fmt.Errorf("messages: mark as read failed: %w", err)
+	}
+	return nil
+}
+
+func (r *postgresRepository) CountUnread(ctx context.Context, userID string) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT t.id)
+		FROM messages m
+		JOIN transactions t ON t.id = m.transaction_id
+		JOIN listings l     ON l.id = t.listing_id
+		WHERE (t.borrower_id = $1 OR l.owner_id = $1)
+		  AND m.sender_id != $1
+		  AND t.status IN ('pending', 'awaiting_payment', 'agreed', 'handed_over', 'cancelled', 'pending_review')
+		  AND m.created_at > COALESCE(
+		      (SELECT cr.last_read_at FROM chat_reads cr
+		       WHERE cr.user_id = $1 AND cr.transaction_id = t.id),
+		      '1970-01-01'::timestamptz
+		  )
+	`, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("messages: count unread failed: %w", err)
+	}
+	return count, nil
 }

--- a/backend/internal/messages/repository.go
+++ b/backend/internal/messages/repository.go
@@ -9,4 +9,6 @@ type Repository interface {
 	FindByID(ctx context.Context, id string) (*Message, error)
 	Create(ctx context.Context, m Message) (*Message, error)
 	FindActiveByParticipant(ctx context.Context, userID string) ([]Message, error)
+	MarkAsRead(ctx context.Context, userID, transactionID string) error
+	CountUnread(ctx context.Context, userID string) (int, error)
 }

--- a/backend/internal/transactions/domain.go
+++ b/backend/internal/transactions/domain.go
@@ -18,6 +18,7 @@ type Transaction struct {
 	StripePaymentIntentID string     `json:"stripe_payment_intent_id,omitempty"`
 	PaymentMethodID       string     `json:"payment_method_id,omitempty"`
 	TotalChargedCents     int64      `json:"total_charged_cents,omitempty"`
+	PaymentMethod         string     `json:"payment_method,omitempty"`
 	StartDate             *time.Time `json:"start_date"`
 	EndDate               *time.Time `json:"end_date"`
 	AgreedAt              *time.Time `json:"agreed_at"`

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -377,7 +377,7 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 	}
 
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(depositAmountCents * int64(result.DaysBorrowed+4) / 100)
+	pointsEarned := int((depositAmountCents - PlatformFeeCents) * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}
@@ -621,7 +621,7 @@ func (h *Handler) confirmReturn(c *gin.Context) {
 		return
 	}
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(body.DepositAmountCents * int64(result.DaysBorrowed+4) / 100)
+	pointsEarned := int((body.DepositAmountCents - PlatformFeeCents) * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
 	}

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -370,16 +370,22 @@ func (h *Handler) returnTransaction(c *gin.Context) {
 		return
 	}
 
-	daysBorrowed, err := h.service.Return(c.Request.Context(), id, depositAmountCents)
+	result, err := h.service.Return(c.Request.Context(), id, depositAmountCents)
 	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(depositAmountCents * int64(daysBorrowed+4) / 100)
+	pointsEarned := int(depositAmountCents * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
+	}
+
+	if result.PaymentMethod == "points" {
+		if err := h.walletSvc.AddPoints(c.Request.Context(), result.BorrowerID, int(result.RefundAmountCents)); err != nil {
+			slog.Error("failed to refund points to borrower after return", "transaction_id", id, "error", err)
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"success": true})
@@ -609,15 +615,20 @@ func (h *Handler) confirmReturn(c *gin.Context) {
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": "invalid return code"})
 		return
 	}
-	daysBorrowed, err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents)
+	result, err := h.service.Return(c.Request.Context(), id, body.DepositAmountCents)
 	if err != nil {
 		h.handleServiceError(c, "return", id, err)
 		return
 	}
 	ownerID := c.MustGet("userID").(string)
-	pointsEarned := int(body.DepositAmountCents * int64(daysBorrowed+4) / 100)
+	pointsEarned := int(body.DepositAmountCents * int64(result.DaysBorrowed+4) / 100)
 	if err := h.walletSvc.AddPoints(c.Request.Context(), ownerID, pointsEarned); err != nil {
 		slog.Error("failed to award points after return", "transaction_id", id, "error", err)
+	}
+	if result.PaymentMethod == "points" {
+		if err := h.walletSvc.AddPoints(c.Request.Context(), result.BorrowerID, int(result.RefundAmountCents)); err != nil {
+			slog.Error("failed to refund points to borrower after return", "transaction_id", id, "error", err)
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{"success": true})
 }

--- a/backend/internal/transactions/handler.go
+++ b/backend/internal/transactions/handler.go
@@ -2,6 +2,7 @@ package transactions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -19,13 +20,13 @@ type adminChecker interface {
 type Handler struct {
 	repo      Repository
 	service   *Service
-	walletSvc pointsAdder
+	walletSvc pointsWallet
 	notifSvc  notificationCreator
 	adminSvc  adminChecker
 }
 
-// NewHandler creates a new Handler injecting the Repository, Service, and a pointsAdder.
-func NewHandler(repo Repository, service *Service, walletSvc pointsAdder, notifSvc notificationCreator, adminSvc adminChecker) *Handler {
+// NewHandler creates a new Handler injecting the Repository, Service, and a pointsWallet.
+func NewHandler(repo Repository, service *Service, walletSvc pointsWallet, notifSvc notificationCreator, adminSvc adminChecker) *Handler {
 	return &Handler{repo: repo, service: service, walletSvc: walletSvc, notifSvc: notifSvc, adminSvc: adminSvc}
 }
 
@@ -291,16 +292,24 @@ func (h *Handler) payTransaction(c *gin.Context) {
 
 	var body struct {
 		DepositAmountCents int64  `json:"deposit_amount_cents"`
-		PaymentMethodID    string `json:"payment_method_id" binding:"required"`
+		PaymentMethodID    string `json:"payment_method_id"`
+		PaymentMethod      string `json:"payment_method"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		slog.Error("failed to parse pay transaction body", "error", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	if body.PaymentMethod == "" {
+		body.PaymentMethod = "card"
+	}
 
-	clientSecret, err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID)
+	clientSecret, err := h.service.ConfirmPayment(c.Request.Context(), id, body.DepositAmountCents, body.PaymentMethodID, body.PaymentMethod)
 	if err != nil {
+		if errors.Is(err, ErrInsufficientPoints) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
+			return
+		}
 		h.handleServiceError(c, "pay", id, err)
 		return
 	}

--- a/backend/internal/transactions/handler_test.go
+++ b/backend/internal/transactions/handler_test.go
@@ -899,3 +899,105 @@ func TestHandoverTransaction_WrongStatus_Returns409(t *testing.T) {
 
 	assert.Equal(t, http.StatusConflict, w.Code)
 }
+
+// ---- Points payment integration tests ----
+
+func setupRouterWithWallet(repo transactions.Repository, fs *fakeStripe, wallet *mockPointsWallet) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(gin.Recovery())
+	svc := transactions.NewService(repo, fs, &noopListingUpdater{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+	h := transactions.NewHandler(repo, svc, wallet, &noopNotificationCreator{}, &mockAdminChecker{})
+	api := r.Group("/api")
+	h.RegisterRoutes(api, middleware.RequireAuth(testJWTSecret))
+	return r
+}
+
+func TestPayTransaction_WithPoints_Success(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 1000} // enough for deposit(800)+fee(200)
+
+	router := setupRouterWithWallet(repo, &fakeStripe{}, wallet)
+
+	body := `{"deposit_amount_cents":800,"payment_method":"points"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/pay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "agreed", repo.transactions[0].Status)
+	assert.Equal(t, "points", repo.transactions[0].PaymentMethod)
+}
+
+func TestPayTransaction_WithPoints_InsufficientFunds_Returns422(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 500} // not enough for deposit(800)+fee(200)=1000
+
+	router := setupRouterWithWallet(repo, &fakeStripe{}, wallet)
+
+	body := `{"deposit_amount_cents":800,"payment_method":"points"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/transactions/tx-1/pay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("borrower-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
+	assert.Equal(t, "awaiting_payment", repo.transactions[0].Status)
+}
+
+func TestHandoverTransaction_SkipsStripe_WhenPointsPayment(t *testing.T) {
+	fs := &fakeStripe{}
+	repo := &fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed", PaymentMethod: "points", ListingID: "lst-1"},
+		},
+	}
+	router := setupRouterWithWallet(repo, fs, &mockPointsWallet{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/handover", bytes.NewReader([]byte{}))
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, fs.captureCalled)
+}
+
+func TestReturnTransaction_SkipsStripeAndRefundsPoints_WhenPointsPayment(t *testing.T) {
+	handoverAt := time.Now().Add(-24 * time.Hour)
+	fs := &fakeStripe{}
+	repo := &fakeRepository{
+		ownerByTransactionID: map[string]string{"tx-1": "owner-1"},
+		transactions: []transactions.Transaction{
+			{
+				ID: "tx-1", Status: "handed_over", PaymentMethod: "points",
+				BorrowerID: "borrower-1", ListingID: "lst-1", HandoverAt: &handoverAt,
+			},
+		},
+	}
+	wallet := &mockPointsWallet{}
+	router := setupRouterWithWallet(repo, fs, wallet)
+
+	body := `{"deposit_amount_cents":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/transactions/tx-1/return", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", makeToken("owner-1"))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int64(0), fs.releasedAmount) // Stripe NOT called
+	assert.Greater(t, wallet.added, 0)            // borrower received points refund
+}

--- a/backend/internal/transactions/postgres_repository.go
+++ b/backend/internal/transactions/postgres_repository.go
@@ -54,13 +54,14 @@ func (r *postgresRepository) FindByID(ctx context.Context, id string) (*Transact
 			COALESCE(stripe_payment_intent_id, '') AS stripe_payment_intent_id,
 			COALESCE(payment_method_id, '')        AS payment_method_id,
 			total_charged_cents, start_date, end_date, agreed_at, handover_at, return_at,
-			dispute_refund_points
+			dispute_refund_points,
+			COALESCE(payment_method, 'card')       AS payment_method
 		FROM transactions
 		WHERE id = $1
 	`, id).Scan(&t.ID, &t.ListingID, &t.BorrowerID, &t.Status,
 		&t.StripePaymentIntentID, &t.PaymentMethodID,
 		&t.TotalChargedCents, &t.StartDate, &t.EndDate, &t.AgreedAt, &t.HandoverAt, &t.ReturnAt,
-		&t.DisputeRefundPoints)
+		&t.DisputeRefundPoints, &t.PaymentMethod)
 
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -188,12 +189,28 @@ func (r *postgresRepository) UpdatePaymentIntent(ctx context.Context, id string,
 		SET stripe_payment_intent_id = $1,
 		    payment_method_id        = $2,
 		    total_charged_cents      = $3,
+		    payment_method           = 'card',
 		    status                   = 'agreed',
 		    agreed_at                = NOW()
 		WHERE id = $4
 	`, paymentIntentID, paymentMethodID, totalChargedCents, id)
 	if err != nil {
 		return fmt.Errorf("transactions: update payment intent failed: %w", err)
+	}
+	return nil
+}
+
+func (r *postgresRepository) SetAgreedWithPoints(ctx context.Context, id string, totalChargedCents int64) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE transactions
+		SET total_charged_cents = $1,
+		    payment_method      = 'points',
+		    status              = 'agreed',
+		    agreed_at           = NOW()
+		WHERE id = $2
+	`, totalChargedCents, id)
+	if err != nil {
+		return fmt.Errorf("transactions: set agreed with points failed: %w", err)
 	}
 	return nil
 }

--- a/backend/internal/transactions/repository.go
+++ b/backend/internal/transactions/repository.go
@@ -17,6 +17,10 @@ type Repository interface {
 	// charged amount on the transaction and sets its status to agreed.
 	UpdatePaymentIntent(ctx context.Context, id string, paymentIntentID string, paymentMethodID string, totalChargedCents int64) error
 
+	// SetAgreedWithPoints sets the transaction to agreed status after a points payment,
+	// recording the total cost without creating a Stripe PaymentIntent.
+	SetAgreedWithPoints(ctx context.Context, id string, totalChargedCents int64) error
+
 	// UpdateStatus updates only the status field and the corresponding timestamp.
 	// validStatuses: handed_over (sets handover_at), returned (sets return_at), cancelled.
 	UpdateStatus(ctx context.Context, id string, status string) error

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -165,7 +165,7 @@ func (s *Service) Handover(ctx context.Context, transactionID string) error {
 		return fmt.Errorf("service: transaction %s must be in agreed status to hand over", transactionID)
 	}
 
-	if !isDevPaymentIntent(t.StripePaymentIntentID) {
+	if t.PaymentMethod != "points" && !isDevPaymentIntent(t.StripePaymentIntentID) {
 		if err := s.stripe.CaptureDeposit(t.StripePaymentIntentID); err != nil {
 			return fmt.Errorf("service: capture deposit: %w", err)
 		}
@@ -181,40 +181,54 @@ func (s *Service) Handover(ctx context.Context, transactionID string) error {
 	return nil
 }
 
+// ReturnResult holds the outcome of a Return call so the handler can apply post-return actions.
+type ReturnResult struct {
+	DaysBorrowed      int
+	RefundAmountCents int64
+	PaymentMethod     string
+	BorrowerID        string
+}
+
 // Return refunds a variable percentage of the deposit to the borrower based on days borrowed,
 // marks the transaction as returned, and updates the listing status back to available.
-// Returns the number of days borrowed so the caller can compute the lender's points.
-func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) (int, error) {
+// Returns a ReturnResult so the caller can apply wallet credits or Stripe release.
+func (s *Service) Return(ctx context.Context, transactionID string, depositAmountCents int64) (*ReturnResult, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
-		return 0, fmt.Errorf("service: find transaction: %w", err)
+		return nil, fmt.Errorf("service: find transaction: %w", err)
 	}
 	if t == nil || t.Status != "handed_over" {
-		return 0, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
+		return nil, fmt.Errorf("service: transaction %s must be in handed_over status to return", transactionID)
 	}
 
 	daysBorrowed := calcDaysBorrowed(*t.HandoverAt, time.Now())
 	refundAmountCents := depositAmountCents * int64(96-daysBorrowed) / 100
 
-	// Stripe requires at least 1 cent for refunds.
-	if refundAmountCents < 1 {
-		refundAmountCents = 1
-	}
-
-	if !isDevPaymentIntent(t.StripePaymentIntentID) {
-		if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, refundAmountCents); err != nil {
-			return 0, fmt.Errorf("service: release deposit: %w", err)
+	if t.PaymentMethod != "points" {
+		// Stripe requires at least 1 cent for refunds.
+		if refundAmountCents < 1 {
+			refundAmountCents = 1
+		}
+		if !isDevPaymentIntent(t.StripePaymentIntentID) {
+			if err := s.stripe.ReleaseDeposit(t.StripePaymentIntentID, refundAmountCents); err != nil {
+				return nil, fmt.Errorf("service: release deposit: %w", err)
+			}
 		}
 	}
 
 	if err := s.repo.UpdateStatus(ctx, transactionID, "returned"); err != nil {
-		return 0, fmt.Errorf("service: update status: %w", err)
+		return nil, fmt.Errorf("service: update status: %w", err)
 	}
 
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "available"); err != nil {
-		return 0, fmt.Errorf("service: update listing status: %w", err)
+		return nil, fmt.Errorf("service: update listing status: %w", err)
 	}
-	return daysBorrowed, nil
+	return &ReturnResult{
+		DaysBorrowed:      daysBorrowed,
+		RefundAmountCents: refundAmountCents,
+		PaymentMethod:     t.PaymentMethod,
+		BorrowerID:        t.BorrowerID,
+	}, nil
 }
 
 // ReportIssue transitions a transaction to pending_review and opens a chat with an admin.

--- a/backend/internal/transactions/service.go
+++ b/backend/internal/transactions/service.go
@@ -2,9 +2,13 @@ package transactions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
+
+// ErrInsufficientPoints is returned when the borrower does not have enough points to pay.
+var ErrInsufficientPoints = errors.New("insufficient points to cover the deposit")
 
 type stripeDepositor interface {
 	AuthorizeDeposit(amountCents int64, currency, paymentMethodID string) (piID string, clientSecret string, err error)
@@ -24,8 +28,9 @@ type messageCreator interface {
 	CreateSystemMessage(ctx context.Context, transactionID, content string) error
 }
 
-type pointsAdder interface {
+type pointsWallet interface {
 	AddPoints(ctx context.Context, userID string, points int) error
+	DeductPoints(ctx context.Context, userID string, points int) (bool, error)
 }
 
 type notificationCreator interface {
@@ -39,12 +44,12 @@ type Service struct {
 	listingSvc listingStatusUpdater
 	adminRepo  adminFinder
 	msgRepo    messageCreator
-	walletSvc  pointsAdder
+	walletSvc  pointsWallet
 	notifSvc   notificationCreator
 }
 
 // NewService creates a new Service instance with the required dependencies.
-func NewService(repo Repository, stripe stripeDepositor, listingSvc listingStatusUpdater, adminRepo adminFinder, msgRepo messageCreator, walletSvc pointsAdder, notifSvc notificationCreator) *Service {
+func NewService(repo Repository, stripe stripeDepositor, listingSvc listingStatusUpdater, adminRepo adminFinder, msgRepo messageCreator, walletSvc pointsWallet, notifSvc notificationCreator) *Service {
 	return &Service{repo: repo, stripe: stripe, listingSvc: listingSvc, adminRepo: adminRepo, msgRepo: msgRepo, walletSvc: walletSvc, notifSvc: notifSvc}
 }
 
@@ -61,9 +66,9 @@ func (s *Service) AcceptRequest(ctx context.Context, transactionID string) error
 	return s.repo.UpdateStatus(ctx, transactionID, "awaiting_payment")
 }
 
-// ConfirmPayment autoriza el depósito en Stripe y mueve la transacción a agreed.
-// Solo puede llamarlo el borrower cuando status = awaiting_payment.
-func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string) (string, error) {
+// ConfirmPayment authorises the deposit and moves the transaction to agreed.
+// paymentMethod must be "card" or "points". Only the borrower can call this when status = awaiting_payment.
+func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depositAmountCents int64, paymentMethodID string, paymentMethod string) (string, error) {
 	t, err := s.repo.FindByID(ctx, transactionID)
 	if err != nil {
 		return "", fmt.Errorf("service: find transaction: %w", err)
@@ -73,11 +78,28 @@ func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depo
 	}
 
 	totalCents := depositAmountCents + PlatformFeeCents
+
+	if paymentMethod == "points" {
+		ok, err := s.walletSvc.DeductPoints(ctx, t.BorrowerID, int(totalCents))
+		if err != nil {
+			return "", fmt.Errorf("service: deduct points: %w", err)
+		}
+		if !ok {
+			return "", ErrInsufficientPoints
+		}
+		if err := s.repo.SetAgreedWithPoints(ctx, transactionID, totalCents); err != nil {
+			return "", fmt.Errorf("service: set agreed with points: %w", err)
+		}
+		if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "pending_handover"); err != nil {
+			return "", fmt.Errorf("service: update listing status: %w", err)
+		}
+		return "", nil
+	}
+
 	actualPaymentMethodID := paymentMethodID
 	if actualPaymentMethodID == "" {
 		actualPaymentMethodID = t.PaymentMethodID
 	}
-
 	if actualPaymentMethodID == "" {
 		return "", fmt.Errorf("service: payment method ID is required")
 	}
@@ -86,11 +108,9 @@ func (s *Service) ConfirmPayment(ctx context.Context, transactionID string, depo
 	if err != nil {
 		return "", fmt.Errorf("service: authorize deposit: %w", err)
 	}
-
 	if err := s.repo.UpdatePaymentIntent(ctx, transactionID, stripePIID, actualPaymentMethodID, totalCents); err != nil {
 		return "", fmt.Errorf("service: update payment intent: %w", err)
 	}
-
 	if err := s.listingSvc.UpdateStatus(ctx, t.ListingID, "pending_handover"); err != nil {
 		return "", fmt.Errorf("service: update listing status: %w", err)
 	}

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -99,7 +99,7 @@ func TestConfirmPayment_ChargesDepositPlusPlatformFee(t *testing.T) {
 	lsvc := &fakeListingSvc{}
 	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(700), fs.capturedAmount) // 500 deposit + 200 platform fee
@@ -115,7 +115,7 @@ func TestConfirmPayment_FailsIfNotAwaitingPayment(t *testing.T) {
 	}
 	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.Error(t, err)
 	assert.Empty(t, cs)
@@ -130,7 +130,7 @@ func TestConfirmPayment_ReturnsClientSecret(t *testing.T) {
 	fs := &fakeStripe{clientSecret: "pi_secret_xyz_secret"}
 	svc := transactions.NewService(repo, fs, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new")
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "pm_new", "card")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "pi_secret_xyz_secret", cs)

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -201,10 +201,10 @@ func TestReturn_VariableRefundByDays(t *testing.T) {
 			lsvc := &fakeListingSvc{}
 			svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-			daysBorrowed, err := svc.Return(context.Background(), "tx-1", tc.deposit)
+			res, err := svc.Return(context.Background(), "tx-1", tc.deposit)
 
 			assert.NoError(t, err)
-			assert.Equal(t, tc.wantDayReturned, daysBorrowed)
+			assert.Equal(t, tc.wantDayReturned, res.DaysBorrowed)
 			assert.Equal(t, tc.wantRefund, fs.releasedAmount)
 			assert.Equal(t, "lst-1", lsvc.updatedListingID)
 			assert.Equal(t, "available", lsvc.updatedStatus)
@@ -232,11 +232,12 @@ func TestReturn_PlatformFeeNotRefunded(t *testing.T) {
 	lsvc := &fakeListingSvc{}
 	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-	_, err := svc.Return(context.Background(), "tx-1", deposit)
+	res, err := svc.Return(context.Background(), "tx-1", deposit)
 
 	assert.NoError(t, err)
 	// refundAmount must be strictly less than the deposit (fee not refunded, and lender keeps a share)
 	assert.Less(t, fs.releasedAmount, deposit)
+	assert.NotNil(t, res)
 	assert.Equal(t, "lst-1", lsvc.updatedListingID)
 	assert.Equal(t, "available", lsvc.updatedStatus)
 }
@@ -259,10 +260,10 @@ func TestReturn_DaysClamped(t *testing.T) {
 		lsvc := &fakeListingSvc{}
 		svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+		res, err := svc.Return(context.Background(), "tx-1", 10000)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 1, daysBorrowed)
+		assert.Equal(t, 1, res.DaysBorrowed)
 		assert.Equal(t, "lst-1", lsvc.updatedListingID)
 		assert.Equal(t, "available", lsvc.updatedStatus)
 	})
@@ -284,10 +285,10 @@ func TestReturn_DaysClamped(t *testing.T) {
 		lsvc := &fakeListingSvc{}
 		svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
 
-		daysBorrowed, err := svc.Return(context.Background(), "tx-1", 10000)
+		res, err := svc.Return(context.Background(), "tx-1", 10000)
 
 		assert.NoError(t, err)
-		assert.Equal(t, 7, daysBorrowed)
+		assert.Equal(t, 7, res.DaysBorrowed)
 		assert.Equal(t, "lst-1", lsvc.updatedListingID)
 		assert.Equal(t, "available", lsvc.updatedStatus)
 	})

--- a/backend/internal/transactions/service_test.go
+++ b/backend/internal/transactions/service_test.go
@@ -306,3 +306,123 @@ func TestReturn_FailsIfNotHandedOver(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+// --- Points payment unit tests ---
+
+func TestConfirmPayment_WithPoints_ExactBalance(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	wallet := &mockPointsWallet{points: 700} // exactly deposit(500) + fee(200)
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.NoError(t, err)
+	assert.Empty(t, cs)
+	assert.False(t, fs.captureCalled)
+	assert.Equal(t, int64(700), wallet.deducted)
+	assert.Equal(t, "agreed", repo.transactions[0].Status)
+	assert.Equal(t, "points", repo.transactions[0].PaymentMethod)
+	assert.Equal(t, "pending_handover", lsvc.updatedStatus)
+}
+
+func TestConfirmPayment_WithPoints_InsufficientFunds(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 699} // one point short of deposit(500)+fee(200)
+	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	cs, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.ErrorIs(t, err, transactions.ErrInsufficientPoints)
+	assert.Empty(t, cs)
+	assert.Equal(t, "awaiting_payment", repo.transactions[0].Status)
+}
+
+func TestConfirmPayment_WithPoints_ZeroBalance(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "awaiting_payment", BorrowerID: "borrower-1", ListingID: "lst-1"},
+		},
+	}
+	wallet := &mockPointsWallet{points: 0}
+	svc := transactions.NewService(repo, &fakeStripe{}, &fakeListingSvc{}, &mockAdminFinder{}, &mockMessageCreator{}, wallet, &noopNotificationCreator{})
+
+	_, err := svc.ConfirmPayment(context.Background(), "tx-1", 500, "", "points")
+
+	assert.ErrorIs(t, err, transactions.ErrInsufficientPoints)
+}
+
+func TestHandover_SkipsStripeForPointsPayment(t *testing.T) {
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{ID: "tx-1", Status: "agreed", PaymentMethod: "points", ListingID: "lst-1"},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
+
+	err := svc.Handover(context.Background(), "tx-1")
+
+	assert.NoError(t, err)
+	assert.False(t, fs.captureCalled)
+	assert.Equal(t, "handed_over", repo.transactions[0].Status)
+}
+
+func TestReturn_RefundsPointsWhenPaidWithPoints(t *testing.T) {
+	handoverAt := time.Now().UTC().AddDate(0, 0, -1) // 1 day borrowed
+	repo := &fakeRepository{
+		transactions: []transactions.Transaction{
+			{
+				ID:            "tx-1",
+				Status:        "handed_over",
+				PaymentMethod: "points",
+				BorrowerID:    "borrower-1",
+				ListingID:     "lst-1",
+				HandoverAt:    &handoverAt,
+			},
+		},
+	}
+	fs := &fakeStripe{}
+	lsvc := &fakeListingSvc{}
+	svc := transactions.NewService(repo, fs, lsvc, &mockAdminFinder{}, &mockMessageCreator{}, &noopPointsAdder{}, &noopNotificationCreator{})
+
+	res, err := svc.Return(context.Background(), "tx-1", 10000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), fs.releasedAmount) // Stripe NOT called
+	assert.Equal(t, "points", res.PaymentMethod)
+	assert.Equal(t, "borrower-1", res.BorrowerID)
+	assert.Equal(t, int64(9500), res.RefundAmountCents) // 95% of 10000
+	assert.Equal(t, "available", lsvc.updatedStatus)
+}
+
+// mockPointsWallet tracks deductions for assertions.
+type mockPointsWallet struct {
+	points   int
+	deducted int64
+	added    int
+}
+
+func (m *mockPointsWallet) AddPoints(_ context.Context, _ string, pts int) error {
+	m.added += pts
+	return nil
+}
+
+func (m *mockPointsWallet) DeductPoints(_ context.Context, _ string, amount int) (bool, error) {
+	if m.points < amount {
+		return false, nil
+	}
+	m.points -= amount
+	m.deducted = int64(amount)
+	return true, nil
+}

--- a/backend/internal/transactions/shared_test.go
+++ b/backend/internal/transactions/shared_test.go
@@ -147,6 +147,23 @@ func (f *fakeRepository) UpdatePaymentIntent(_ context.Context, id string, payme
 		if t.ID == id {
 			f.transactions[i].StripePaymentIntentID = paymentIntentID
 			f.transactions[i].PaymentMethodID = paymentMethodID
+			f.transactions[i].TotalChargedCents = totalChargedCents
+			f.transactions[i].PaymentMethod = "card"
+			f.transactions[i].Status = "agreed"
+			f.transactions[i].AgreedAt = &now
+			return nil
+		}
+	}
+	return fmt.Errorf("transaction %s not found", id)
+}
+
+func (f *fakeRepository) SetAgreedWithPoints(_ context.Context, id string, totalChargedCents int64) error {
+	if f.err != nil { return f.err }
+	now := time.Now()
+	for i, t := range f.transactions {
+		if t.ID == id {
+			f.transactions[i].TotalChargedCents = totalChargedCents
+			f.transactions[i].PaymentMethod = "points"
 			f.transactions[i].Status = "agreed"
 			f.transactions[i].AgreedAt = &now
 			return nil

--- a/backend/internal/transactions/shared_test.go
+++ b/backend/internal/transactions/shared_test.go
@@ -12,7 +12,10 @@ import (
 // --- Shared Mocks ---
 
 type noopPointsAdder struct{}
-func (noopPointsAdder) AddPoints(_ context.Context, _ string, _ int) error { return nil }
+func (noopPointsAdder) AddPoints(_ context.Context, _ string, _ int) error   { return nil }
+func (noopPointsAdder) DeductPoints(_ context.Context, _ string, _ int) (bool, error) {
+	return true, nil
+}
 
 type noopNotificationCreator struct{}
 func (noopNotificationCreator) Create(_ context.Context, _ string, _ string, _ map[string]any) error { return nil }

--- a/backend/internal/users/handler.go
+++ b/backend/internal/users/handler.go
@@ -32,8 +32,24 @@ func (h *Handler) RegisterRoutes(rg *gin.RouterGroup, authMiddleware gin.Handler
 
 	protected := rg.Group("/")
 	protected.Use(authMiddleware)
+	protected.GET("/users/me", h.getMe)
 	protected.PUT("/users/me", h.updateMe)
 	protected.POST("/users/me/avatar", h.uploadAvatar)
+}
+
+func (h *Handler) getMe(c *gin.Context) {
+	userID := c.MustGet("userID").(string)
+	user, err := h.repo.FindByID(c.Request.Context(), userID)
+	if err != nil {
+		slog.Error("failed to get current user", "id", userID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+		return
+	}
+	if user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": user})
 }
 
 func (h *Handler) listUsers(c *gin.Context) {

--- a/backend/internal/wallet/domain.go
+++ b/backend/internal/wallet/domain.go
@@ -44,6 +44,9 @@ type PointsHistoryEntry struct {
 type Repository interface {
 	GetPoints(ctx context.Context, userID string) (int, error)
 	AddPoints(ctx context.Context, userID string, delta int) error
+	// DeductPoints atomically removes points only if the balance is sufficient.
+	// Returns true if deducted, false (no error) if balance was insufficient.
+	DeductPoints(ctx context.Context, userID string, amount int) (bool, error)
 	CreateRedemption(ctx context.Context, userID string, points int) (*Redemption, error)
 	GetPointsHistory(ctx context.Context, userID string) ([]PointsHistoryEntry, error)
 	GetStripeConnectAccountID(ctx context.Context, userID string) (string, error)
@@ -53,6 +56,9 @@ type Repository interface {
 // Service is the business-logic contract for the wallet package.
 type Service interface {
 	AddPoints(ctx context.Context, userID string, points int) error
+	// DeductPoints atomically removes points only if balance is sufficient.
+	// Returns true if deducted, false (no error) if insufficient.
+	DeductPoints(ctx context.Context, userID string, points int) (bool, error)
 	RedeemPoints(ctx context.Context, userID string, pointsToRedeem int) (*Redemption, error)
 	GetPointsHistory(ctx context.Context, userID string) ([]PointsHistoryEntry, error)
 }

--- a/backend/internal/wallet/handler_test.go
+++ b/backend/internal/wallet/handler_test.go
@@ -66,6 +66,17 @@ func (f *fakeRepository) UpdateRedemptionStatus(_ context.Context, _, _ string) 
 	return nil
 }
 
+func (f *fakeRepository) DeductPoints(_ context.Context, _ string, amount int) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if f.points < amount {
+		return false, nil
+	}
+	f.points -= amount
+	return true, nil
+}
+
 // fakeStripe implements wallet.StripePayouter for tests.
 type fakeStripe struct{ fail bool }
 

--- a/backend/internal/wallet/postgres_repository.go
+++ b/backend/internal/wallet/postgres_repository.go
@@ -33,6 +33,16 @@ func (r *postgresRepository) AddPoints(ctx context.Context, userID string, delta
 	return nil
 }
 
+func (r *postgresRepository) DeductPoints(ctx context.Context, userID string, amount int) (bool, error) {
+	res, err := r.pool.Exec(ctx,
+		`UPDATE users SET points = points - $1 WHERE id = $2 AND points >= $1`,
+		amount, userID)
+	if err != nil {
+		return false, fmt.Errorf("wallet: deduct points failed: %w", err)
+	}
+	return res.RowsAffected() > 0, nil
+}
+
 func (r *postgresRepository) CreateRedemption(ctx context.Context, userID string, points int) (*Redemption, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {

--- a/backend/internal/wallet/service.go
+++ b/backend/internal/wallet/service.go
@@ -19,6 +19,10 @@ func (s *service) AddPoints(ctx context.Context, userID string, points int) erro
 	return s.repo.AddPoints(ctx, userID, points)
 }
 
+func (s *service) DeductPoints(ctx context.Context, userID string, points int) (bool, error) {
+	return s.repo.DeductPoints(ctx, userID, points)
+}
+
 func (s *service) RedeemPoints(ctx context.Context, userID string, pointsToRedeem int) (*Redemption, error) {
 	balance, err := s.repo.GetPoints(ctx, userID)
 	if err != nil {

--- a/frontend/src/__tests__/ChatDetailPage.test.tsx
+++ b/frontend/src/__tests__/ChatDetailPage.test.tsx
@@ -65,6 +65,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     currentUserId = BORROWER_ID; // por defecto: borrower
     vi.mocked(messagesLib.messagesApi.getByTransaction).mockResolvedValue([]);
+    vi.mocked(messagesLib.messagesApi.markAsRead).mockResolvedValue(undefined);
     vi.mocked(messagesLib.messagesApi.create).mockResolvedValue({
         id: 'msg-new',
         transaction_id: TX_ID,

--- a/frontend/src/__tests__/ChatsPage.test.tsx
+++ b/frontend/src/__tests__/ChatsPage.test.tsx
@@ -103,11 +103,11 @@ describe('ChatsPage', () => {
         });
     });
 
-    it('muestra la sección "Sin mensajes" para chats sin contenido', async () => {
+    it('muestra el estado de transacción para chats sin contenido', async () => {
         vi.mocked(messagesApi.getActiveChats).mockResolvedValue(mockChats);
         renderPage();
         await waitFor(() => {
-            expect(screen.getByText('Sin mensajes')).toBeInTheDocument();
+            expect(screen.getByText('Inicia la conversación para concretar la entrega')).toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/__tests__/PaymentModal.test.tsx
+++ b/frontend/src/__tests__/PaymentModal.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import PaymentModal from '../components/PaymentModal';
+
+// Stripe mocks (PaymentForm imports these)
+vi.mock('@stripe/stripe-js', () => ({ loadStripe: vi.fn().mockResolvedValue(null) }));
+vi.mock('@stripe/react-stripe-js', () => ({
+    Elements: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CardNumberElement: () => <div data-testid="card-number" />,
+    CardExpiryElement: () => <div data-testid="card-expiry" />,
+    CardCvcElement: () => <div data-testid="card-cvc" />,
+    useStripe: () => ({
+        createPaymentMethod: vi.fn().mockResolvedValue({ paymentMethod: { id: 'pm_123' }, error: undefined }),
+        handleNextAction: vi.fn().mockResolvedValue({}),
+        retrievePaymentIntent: vi.fn().mockResolvedValue({ paymentIntent: { status: 'succeeded' } }),
+    }),
+    useElements: () => ({ getElement: vi.fn().mockReturnValue({}) }),
+}));
+
+vi.mock('../lib/transactions', () => ({
+    transactionsApi: {
+        pay: vi.fn().mockResolvedValue({ clientSecret: '' }),
+    },
+}));
+
+import { transactionsApi } from '../lib/transactions';
+
+const baseProps = {
+    transactionId: 'tx-1',
+    depositAmount: 50,
+    startDate: '2026-06-10',
+    endDate: '2026-06-11',
+    onClose: vi.fn(),
+    onSuccess: vi.fn(),
+};
+
+// totalCents = 1 day * 50€ * 100 + 200 = 5200
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('PaymentModal — selector de método de pago', () => {
+    it('muestra el selector de método de pago al abrir', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        expect(screen.getByText('Método de pago')).toBeDefined();
+        expect(screen.getByText('Pagar con tarjeta')).toBeDefined();
+    });
+
+    it('muestra la opción de puntos cuando el saldo es suficiente', () => {
+        render(<PaymentModal {...baseProps} userPoints={5200} />);
+        expect(screen.getByText('Pagar con puntos')).toBeDefined();
+    });
+
+    it('NO muestra la opción de puntos cuando el saldo es insuficiente', () => {
+        render(<PaymentModal {...baseProps} userPoints={5199} />);
+        expect(screen.queryByText('Pagar con puntos')).toBeNull();
+    });
+
+    it('NO muestra la opción de puntos con saldo 0', () => {
+        render(<PaymentModal {...baseProps} userPoints={0} />);
+        expect(screen.queryByText('Pagar con puntos')).toBeNull();
+    });
+
+    it('navega a la vista de tarjeta al seleccionar "Pagar con tarjeta"', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con tarjeta'));
+        expect(screen.getByText('Datos de pago')).toBeDefined();
+    });
+
+    it('navega a la vista de puntos al seleccionar "Pagar con puntos"', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        expect(screen.getByText('Pagar con puntos', { selector: 'h2' })).toBeDefined();
+    });
+
+    it('vuelve al selector al pulsar la flecha de retroceso', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con tarjeta'));
+        fireEvent.click(screen.getByLabelText('Volver'));
+        expect(screen.getByText('Método de pago')).toBeDefined();
+    });
+});
+
+describe('PaymentModal — pago con puntos', () => {
+    it('muestra el coste y saldo en la vista de puntos', () => {
+        render(<PaymentModal {...baseProps} userPoints={6000} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        // 5200 cents = 52.00 pts; remaining = 6000 - 5200 = 800 cents = 8.00 pts
+        expect(screen.getByText('60.00 pts')).toBeDefined(); // saldo actual
+        expect(screen.getByText('−52.00 pts')).toBeDefined(); // coste
+        expect(screen.getByText('8.00 pts')).toBeDefined();   // saldo tras pago
+    });
+
+    it('llama a transactionsApi.pay con payment_method=points al confirmar', async () => {
+        const onSuccess = vi.fn();
+        render(<PaymentModal {...baseProps} userPoints={6000} onSuccess={onSuccess} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        fireEvent.click(screen.getByText('Confirmar pago'));
+
+        await waitFor(() => expect(transactionsApi.pay).toHaveBeenCalledWith(
+            'tx-1',
+            5000, // depositCents
+            null,
+            'points',
+        ));
+        await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+    });
+
+    it('llama a onPointsDeducted con el total en cents tras el pago', async () => {
+        const onPointsDeducted = vi.fn();
+        render(<PaymentModal {...baseProps} userPoints={6000} onPointsDeducted={onPointsDeducted} />);
+        fireEvent.click(screen.getByText('Pagar con puntos'));
+        fireEvent.click(screen.getByText('Confirmar pago'));
+
+        await waitFor(() => expect(onPointsDeducted).toHaveBeenCalledWith(5200)); // depositCents+200
+    });
+});

--- a/frontend/src/__tests__/ReturnPage.test.tsx
+++ b/frontend/src/__tests__/ReturnPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import ReturnPage from '../pages/ReturnPage'
+import { AuthProvider } from '../contexts/AuthContext'
 import { api } from '../lib/api'
 
 const mockNavigate = vi.fn()
@@ -20,13 +21,21 @@ vi.mock('../lib/api', () => ({
     }
 }))
 
+vi.mock('../lib/users', () => ({
+    usersApi: {
+        getMe: vi.fn().mockResolvedValue({ id: 'u-1', points: 100 }),
+    }
+}))
+
 function renderPage() {
     return render(
-        <MemoryRouter initialEntries={['/listings/abc/return']}>
-            <Routes>
-                <Route path="/listings/:id/return" element={<ReturnPage />} />
-            </Routes>
-        </MemoryRouter>
+        <AuthProvider>
+            <MemoryRouter initialEntries={['/listings/abc/return']}>
+                <Routes>
+                    <Route path="/listings/:id/return" element={<ReturnPage />} />
+                </Routes>
+            </MemoryRouter>
+        </AuthProvider>
     )
 }
 

--- a/frontend/src/__tests__/transactions.test.ts
+++ b/frontend/src/__tests__/transactions.test.ts
@@ -62,7 +62,7 @@ describe('transactionsApi.getById', () => {
 });
 
 describe('transactionsApi.pay', () => {
-    it('envía PUT con el importe correcto', async () => {
+    it('envía PUT con el importe correcto (pago con tarjeta)', async () => {
         fetchMock.mockResolvedValueOnce({
             ok: true,
             status: 200,
@@ -77,7 +77,30 @@ describe('transactionsApi.pay', () => {
                 method: 'PUT',
                 body: JSON.stringify({
                     deposit_amount_cents: 5000,
-                    payment_method_id: 'pm_123'
+                    payment_method_id: 'pm_123',
+                    payment_method: 'card',
+                }),
+            })
+        );
+    });
+
+    it('envía payment_method=points cuando se paga con puntos', async () => {
+        fetchMock.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: async () => ({ client_secret: '' }),
+        });
+
+        await transactionsApi.pay('tx-1', 5000, null, 'points');
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/transactions/tx-1/pay'),
+            expect.objectContaining({
+                method: 'PUT',
+                body: JSON.stringify({
+                    deposit_amount_cents: 5000,
+                    payment_method_id: null,
+                    payment_method: 'points',
                 }),
             })
         );
@@ -90,7 +113,7 @@ describe('transactionsApi.pay', () => {
             json: async () => ({ client_secret: 'pi_secret_abc' }),
         });
 
-        const result = await transactionsApi.pay('tx-1', 5000, 'pm_123');
+        const result = await transactionsApi.pay('tx-1', 5000, 'pm_123', 'card');
 
         expect(result.clientSecret).toBe('pi_secret_abc');
     });
@@ -101,6 +124,6 @@ describe('transactionsApi.pay', () => {
             json: async () => ({ error: 'transaction not in awaiting_payment state' }),
         });
 
-        await expect(transactionsApi.pay('tx-1', 5000, 'pm_123')).rejects.toThrow('awaiting_payment');
+        await expect(transactionsApi.pay('tx-1', 5000, 'pm_123', 'card')).rejects.toThrow('awaiting_payment');
     });
 });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import notificacionIcon from '../assets/notificacion.jpg';
 import { notificationsApi } from '../lib/notifications';
+import { messagesApi } from '../lib/messages';
 import type { Notification } from '../types';
 
 function formatNotificationText(notification: Notification): string {
@@ -38,6 +39,7 @@ export default function Layout() {
     const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
     const [notifications, setNotifications] = useState<Notification[]>([]);
     const [unreadCount, setUnreadCount] = useState(0);
+    const [unreadChatsCount, setUnreadChatsCount] = useState(0);
     const [loadingNotifications, setLoadingNotifications] = useState(false);
     const notificationsRef = useRef<HTMLDivElement>(null);
 
@@ -72,6 +74,15 @@ export default function Layout() {
                 // silencioso
             }
         }, 30_000);
+        return () => clearInterval(interval);
+    }, [user]);
+
+    useEffect(() => {
+        if (!user) return;
+        const fetchUnreadChats = () =>
+            messagesApi.getUnreadCount().then(setUnreadChatsCount).catch(() => {});
+        fetchUnreadChats();
+        const interval = setInterval(fetchUnreadChats, 30_000);
         return () => clearInterval(interval);
     }, [user]);
 
@@ -160,12 +171,17 @@ export default function Layout() {
                                 {/* Chats */}
                                 <Link
                                     to="/chats"
-                                    className="inline-flex h-10 w-10 items-center justify-center rounded-full text-gray-800 hover:bg-gray-100"
+                                    className="relative inline-flex h-10 w-10 items-center justify-center rounded-full text-gray-800 hover:bg-gray-100"
                                     aria-label="Chats"
                                 >
                                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                                         <path d="M12 2C6.477 2 2 6.477 2 12c0 1.89.52 3.66 1.424 5.168L2.1 21.1a.75.75 0 00.943.943l3.932-1.324A9.956 9.956 0 0012 22c5.523 0 10-4.477 10-10S17.523 2 12 2zM8 13a1 1 0 110-2 1 1 0 010 2zm4 0a1 1 0 110-2 1 1 0 010 2zm4 0a1 1 0 110-2 1 1 0 010 2z" />
                                     </svg>
+                                    {unreadChatsCount > 0 && (
+                                        <span className="absolute top-2 right-2 flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] text-white ring-2 ring-white">
+                                            {unreadChatsCount > 9 ? '9+' : unreadChatsCount}
+                                        </span>
+                                    )}
                                 </Link>
 
                                 {/* Perfil */}

--- a/frontend/src/components/PaymentModal.tsx
+++ b/frontend/src/components/PaymentModal.tsx
@@ -2,13 +2,17 @@ import { useState, useRef } from 'react';
 import PaymentForm, { type PaymentFormHandle } from './PaymentForm';
 import { transactionsApi } from '../lib/transactions';
 
+type PaymentStep = 'select' | 'card' | 'points';
+
 interface Props {
     transactionId: string;
     depositAmount: number;
     startDate: string;
     endDate: string;
+    userPoints: number;
     onClose: () => void;
     onSuccess: () => void;
+    onPointsDeducted?: (cents: number) => void;
 }
 
 export default function PaymentModal({
@@ -16,9 +20,12 @@ export default function PaymentModal({
     depositAmount,
     startDate,
     endDate,
+    userPoints,
     onClose,
-    onSuccess
+    onSuccess,
+    onPointsDeducted,
 }: Props) {
+    const [step, setStep] = useState<PaymentStep>('select');
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const paymentFormRef = useRef<PaymentFormHandle>(null);
@@ -26,17 +33,19 @@ export default function PaymentModal({
     const start = new Date(startDate);
     const end = new Date(endDate);
     const diffMs = end.getTime() - start.getTime();
-    const days = Math.max(1, Math.round(diffMs / 86400000)) || 1; // Default to 1 day if invalid
+    const days = Math.max(1, Math.round(diffMs / 86400000)) || 1;
     const depositCents = Math.round(days * Number(depositAmount) * 100) || 0;
-    const totalEuros = (depositCents + 200) / 100;
+    const totalCents = depositCents + 200;
+    const totalEuros = totalCents / 100;
+    const canPayWithPoints = userPoints >= totalCents;
 
-    async function handlePay() {
+    async function handleCardPay() {
         if (!paymentFormRef.current) return;
         setSubmitting(true);
         setError(null);
         try {
             const pmId = await paymentFormRef.current.createPaymentMethod();
-            const { clientSecret } = await transactionsApi.pay(transactionId, depositCents, pmId);
+            const { clientSecret } = await transactionsApi.pay(transactionId, depositCents, pmId, 'card');
             await paymentFormRef.current.handleNextAction(clientSecret);
             onSuccess();
         } catch (err: unknown) {
@@ -46,11 +55,38 @@ export default function PaymentModal({
         }
     }
 
+    async function handlePointsPay() {
+        setSubmitting(true);
+        setError(null);
+        try {
+            await transactionsApi.pay(transactionId, depositCents, null, 'points');
+            onPointsDeducted?.(totalCents);
+            onSuccess();
+        } catch (err: unknown) {
+            setError(err instanceof Error ? err.message : 'Error al procesar el pago con puntos');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
     return (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
             <div className="bg-white rounded-[28px] shadow-xl w-full max-w-md p-6">
                 <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-xl font-semibold">Datos de pago</h2>
+                    <div className="flex items-center gap-2">
+                        {step !== 'select' && (
+                            <button
+                                onClick={() => { setStep('select'); setError(null); }}
+                                className="text-gray-400 hover:text-gray-600 mr-1"
+                                aria-label="Volver"
+                            >
+                                ←
+                            </button>
+                        )}
+                        <h2 className="text-xl font-semibold">
+                            {step === 'select' ? 'Método de pago' : step === 'card' ? 'Datos de pago' : 'Pagar con puntos'}
+                        </h2>
+                    </div>
                     <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
                 </div>
 
@@ -60,23 +96,91 @@ export default function PaymentModal({
                     </p>
                 )}
 
-                <PaymentForm ref={paymentFormRef} totalEuros={totalEuros} />
+                {step === 'select' && (
+                    <div className="flex flex-col gap-3">
+                        <button
+                            onClick={() => setStep('card')}
+                            className="w-full flex flex-col items-start p-4 border-2 border-gray-200 rounded-2xl hover:border-[var(--accent)] transition-colors text-left"
+                        >
+                            <span className="font-semibold text-base">Pagar con tarjeta</span>
+                            <span className="text-sm text-gray-500 mt-1">Total: {totalEuros.toFixed(2)} €</span>
+                        </button>
 
-                <div className="flex gap-3 mt-6">
-                    <button
-                        onClick={onClose}
-                        className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
-                    >
-                        Cancelar
-                    </button>
-                    <button
-                        onClick={handlePay}
-                        disabled={submitting}
-                        className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
-                    >
-                        {submitting ? 'Pagando...' : 'Confirmar pago'}
-                    </button>
-                </div>
+                        {canPayWithPoints && (
+                            <button
+                                onClick={() => setStep('points')}
+                                className="w-full flex flex-col items-start p-4 border-2 border-gray-200 rounded-2xl hover:border-[var(--accent)] transition-colors text-left"
+                            >
+                                <span className="font-semibold text-base">Pagar con puntos</span>
+                                <span className="text-sm text-gray-500 mt-1">
+                                    Coste: {(totalCents / 100).toFixed(2)} pts · Saldo: {(userPoints / 100).toFixed(2)} pts
+                                </span>
+                            </button>
+                        )}
+
+                        <button
+                            onClick={onClose}
+                            className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold mt-2"
+                        >
+                            Cancelar
+                        </button>
+                    </div>
+                )}
+
+                {step === 'card' && (
+                    <>
+                        <PaymentForm ref={paymentFormRef} totalEuros={totalEuros} />
+                        <div className="flex gap-3 mt-6">
+                            <button
+                                onClick={onClose}
+                                className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                onClick={handleCardPay}
+                                disabled={submitting}
+                                className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
+                            >
+                                {submitting ? 'Pagando...' : 'Confirmar pago'}
+                            </button>
+                        </div>
+                    </>
+                )}
+
+                {step === 'points' && (
+                    <div className="flex flex-col gap-4">
+                        <div className="bg-gray-50 rounded-2xl p-4 text-sm">
+                            <div className="flex justify-between mb-2">
+                                <span className="text-gray-600">Saldo actual</span>
+                                <span className="font-semibold">{(userPoints / 100).toFixed(2)} pts</span>
+                            </div>
+                            <div className="flex justify-between mb-2">
+                                <span className="text-gray-600">Coste del depósito</span>
+                                <span className="font-semibold text-red-600">−{(totalCents / 100).toFixed(2)} pts</span>
+                            </div>
+                            <div className="border-t pt-2 flex justify-between">
+                                <span className="text-gray-600">Saldo tras el pago</span>
+                                <span className="font-semibold">{((userPoints - totalCents) / 100).toFixed(2)} pts</span>
+                            </div>
+                        </div>
+                        <div className="flex gap-3">
+                            <button
+                                onClick={onClose}
+                                className="px-4 py-2 bg-[var(--surface-strong)] rounded-full font-semibold"
+                            >
+                                Cancelar
+                            </button>
+                            <button
+                                onClick={handlePointsPay}
+                                disabled={submitting}
+                                className="flex-1 bg-[var(--accent)] text-white py-2 rounded-full hover:brightness-95 disabled:opacity-50 font-semibold"
+                            >
+                                {submitting ? 'Procesando...' : 'Confirmar pago'}
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -21,4 +21,10 @@ export const messagesApi = {
 
     getActiveChats: (signal?: AbortSignal) =>
         api.get<MessagesResponse>('/chats', { signal }).then(r => r.data),
+
+    markAsRead: (transactionId: string) =>
+        api.post(`/transactions/${transactionId}/messages/read`).then(() => {}),
+
+    getUnreadCount: (signal?: AbortSignal) =>
+        api.get<{ count: number }>('/chats/unread-count', { signal }).then(r => r.data.count),
 };

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -23,8 +23,8 @@ export const messagesApi = {
         api.get<MessagesResponse>('/chats', { signal }).then(r => r.data),
 
     markAsRead: (transactionId: string) =>
-        api.post(`/transactions/${transactionId}/messages/read`).then(() => {}),
+        api.post(`/transactions/${transactionId}/messages/read`, {}).then(() => {}),
 
     getUnreadCount: (signal?: AbortSignal) =>
-        api.get<{ count: number }>('/chats/unread-count', { signal }).then(r => r.data.count),
+        api.get<{ count: number }>('/chats/unread-count', { signal }).then(r => r.count),
 };

--- a/frontend/src/lib/transactions.ts
+++ b/frontend/src/lib/transactions.ts
@@ -5,10 +5,11 @@ export const transactionsApi = {
     getById: (id: string): Promise<Transaction> =>
         api.get<{ data: Transaction }>(`/transactions/${id}`).then(r => r.data),
 
-    pay: (id: string, depositAmountCents: number, paymentMethodId: string): Promise<{ clientSecret: string }> =>
+    pay: (id: string, depositAmountCents: number, paymentMethodId: string | null, paymentMethod: 'card' | 'points' = 'card'): Promise<{ clientSecret: string }> =>
         api.put<{ client_secret: string }>(`/transactions/${id}/pay`, {
             deposit_amount_cents: depositAmountCents,
-            payment_method_id: paymentMethodId
+            payment_method_id: paymentMethodId,
+            payment_method: paymentMethod,
         }).then(r => ({ clientSecret: r.client_secret })),
 
     reportIssue: (id: string): Promise<void> =>

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -17,6 +17,9 @@ export const usersApi = {
     getUser: (id: string) =>
         api.get<ApiResponse<User>>(`/users/${id}`).then(r => r.data),
 
+    getMe: () =>
+        api.get<ApiResponse<User>>('/users/me').then(r => r.data),
+
     updateMe: (input: UpdateMeInput) =>
         api.put<ApiResponse<User>>('/users/me', input).then(r => r.data),
 

--- a/frontend/src/pages/ReturnPage.tsx
+++ b/frontend/src/pages/ReturnPage.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { api } from '../lib/api';
 import { transactionsApi } from '../lib/transactions';
+import { usersApi } from '../lib/users';
+import { useAuth } from '../contexts/AuthContext';
 
 export default function ReturnPage() {
     const navigate = useNavigate();
     const { id: listingId } = useParams<{ id: string }>();
+    const { updateUser } = useAuth();
 
     const [transactionId, setTransactionId] = useState<string | null>(null);
     const [depositAmountCents, setDepositAmountCents] = useState<number>(0);
@@ -41,6 +44,7 @@ export default function ReturnPage() {
                 deposit_amount_cents: depositAmountCents,
             });
             setSuccess(true);
+            usersApi.getMe().then(me => updateUser(me)).catch(() => {});
             setTimeout(() => navigate('/profile'), 1500);
         } catch {
             setError('Código incorrecto o error al confirmar. Inténtalo de nuevo.');

--- a/frontend/src/pages/chats/ChatDetailPage.tsx
+++ b/frontend/src/pages/chats/ChatDetailPage.tsx
@@ -60,7 +60,7 @@ function getStatusBadge(status?: TransactionStatus): StatusBadge | null {
 
 export default function ChatDetailPage() {
     const { id: transactionId } = useParams<{ id: string }>();
-    const { user } = useAuth();
+    const { user, updateUser } = useAuth();
     const navigate = useNavigate();
 
     const [messages, setMessages] = useState<Message[]>([]);
@@ -307,8 +307,12 @@ export default function ChatDetailPage() {
                     depositAmount={listing.deposit_amount}
                     startDate={transaction.start_date ?? ''}
                     endDate={transaction.end_date ?? ''}
+                    userPoints={user?.points ?? 0}
                     onClose={() => setShowPayment(false)}
                     onSuccess={handlePaymentSuccess}
+                    onPointsDeducted={(cents) => {
+                        if (user) updateUser({ ...user, points: user.points - cents });
+                    }}
                 />
             )}
 

--- a/frontend/src/pages/chats/ChatDetailPage.tsx
+++ b/frontend/src/pages/chats/ChatDetailPage.tsx
@@ -134,6 +134,11 @@ export default function ChatDetailPage() {
         };
     }, [transactionId]);
 
+    useEffect(() => {
+        if (!transactionId) return;
+        messagesApi.markAsRead(transactionId).catch(() => {});
+    }, [transactionId]);
+
     if (!user) return null;
 
     const isOwner = listing?.owner_id === user.id;

--- a/frontend/src/pages/chats/ChatsPage.tsx
+++ b/frontend/src/pages/chats/ChatsPage.tsx
@@ -17,14 +17,7 @@ import type { Message } from '../../types';
 
 type Tab = 'owner' | 'borrower';
 
-type ChatGroups = {
-    disputes: Message[];
-    pending: Message[];
-    awaitingPayment: Message[];
-    rejected: Message[];
-    activeNoMsg: Message[];
-    activeWithMsg: Message[];
-};
+const ACTIVE_STATUSES = ['agreed', 'handed_over', 'returned'];
 
 const STATUS_META = {
     pending: {
@@ -56,64 +49,6 @@ const STATUS_META = {
 
 const sortByDateDesc = (a: Message, b: Message) =>
     new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-
-function classifyChats(chats: Message[]): ChatGroups {
-    const groups: ChatGroups = {
-        disputes: [],
-        pending: [],
-        awaitingPayment: [],
-        rejected: [],
-        activeNoMsg: [],
-        activeWithMsg: [],
-    };
-
-    chats.forEach((chat) => {
-        const status = chat.status ?? '';
-        const hasMessage = chat.content.trim() !== '';
-
-        if (status === 'pending_review') {
-            groups.disputes.push(chat);
-            return;
-        }
-        if (status === 'pending') {
-            groups.pending.push(chat);
-            return;
-        }
-        if (status === 'awaiting_payment') {
-            groups.awaitingPayment.push(chat);
-            return;
-        }
-        if (status === 'cancelled') {
-            groups.rejected.push(chat);
-            return;
-        }
-
-        const isActive = ['agreed', 'handed_over', 'returned'].includes(status);
-        if (isActive && hasMessage) {
-            groups.activeWithMsg.push(chat);
-            return;
-        }
-        if (isActive && !hasMessage) {
-            groups.activeNoMsg.push(chat);
-            return;
-        }
-
-        if (hasMessage) {
-            groups.activeWithMsg.push(chat);
-        } else {
-            groups.activeNoMsg.push(chat);
-        }
-    });
-
-    groups.disputes.sort(sortByDateDesc);
-    groups.pending.sort(sortByDateDesc);
-    groups.awaitingPayment.sort(sortByDateDesc);
-    groups.rejected.sort(sortByDateDesc);
-    groups.activeNoMsg.sort(sortByDateDesc);
-    groups.activeWithMsg.sort(sortByDateDesc);
-
-    return groups;
-}
 
 function ChatCard({ message, currentUserID }: { message: Message; currentUserID: string }) {
     const isMe = message.sender_id === currentUserID;
@@ -208,16 +143,8 @@ function ChatListSkeleton({ count = 4 }: { count?: number }) {
     );
 }
 
-function ChatSection({ groups, currentUserID }: { groups: ChatGroups; currentUserID: string }) {
-    const total =
-        groups.disputes.length +
-        groups.pending.length +
-        groups.awaitingPayment.length +
-        groups.rejected.length +
-        groups.activeNoMsg.length +
-        groups.activeWithMsg.length;
-
-    if (total === 0) {
+function ChatList({ chats, currentUserID }: { chats: Message[]; currentUserID: string }) {
+    if (chats.length === 0) {
         return (
             <div className="text-center py-16 text-[var(--muted)]">
                 <MessageCircle className="h-10 w-10 mx-auto mb-3 text-[var(--accent-3)]" />
@@ -228,63 +155,14 @@ function ChatSection({ groups, currentUserID }: { groups: ChatGroups; currentUse
 
     return (
         <div className="flex flex-col gap-4">
-            {groups.disputes.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--danger)]">Incidencias / Disputas</h2>
-                    {groups.disputes.map((msg) =>
-                        msg.content !== '' ? (
-                            <ChatCard key={msg.id} message={msg} currentUserID={currentUserID} />
-                        ) : (
-                            <TransactionStatusCard key={msg.transaction_id} message={msg} />
-                        )
-                    )}
-                </div>
-            )}
-
-            {groups.pending.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--warning)]">Pendientes</h2>
-                    {groups.pending.map((msg) => (
-                        <TransactionStatusCard key={msg.transaction_id} message={msg} />
-                    ))}
-                </div>
-            )}
-
-            {groups.awaitingPayment.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--success)]">Pendiente de pago</h2>
-                    {groups.awaitingPayment.map((msg) => (
-                        <TransactionStatusCard key={msg.transaction_id} message={msg} />
-                    ))}
-                </div>
-            )}
-
-            {groups.rejected.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--danger)]">Rechazados</h2>
-                    {groups.rejected.map((msg) => (
-                        <TransactionStatusCard key={msg.transaction_id} message={msg} />
-                    ))}
-                </div>
-            )}
-
-            {groups.activeNoMsg.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">Sin mensajes</h2>
-                    {groups.activeNoMsg.map((msg) => (
-                        <TransactionStatusCard key={msg.transaction_id} message={msg} />
-                    ))}
-                </div>
-            )}
-
-            {groups.activeWithMsg.length > 0 && (
-                <div className="flex flex-col gap-2">
-                    <h2 className="text-xs font-semibold uppercase tracking-wide text-[var(--muted)]">Conversaciones</h2>
-                    {groups.activeWithMsg.map((msg) => (
-                        <ChatCard key={msg.id} message={msg} currentUserID={currentUserID} />
-                    ))}
-                </div>
-            )}
+            {chats.map((msg) => {
+                const isActive = ACTIVE_STATUSES.includes(msg.status ?? '');
+                const hasContent = msg.content !== '';
+                if (hasContent && (isActive || msg.status === 'pending_review')) {
+                    return <ChatCard key={msg.id} message={msg} currentUserID={currentUserID} />;
+                }
+                return <TransactionStatusCard key={msg.transaction_id} message={msg} />;
+            })}
         </div>
     );
 }
@@ -313,11 +191,10 @@ export default function ChatsPage() {
     const ownerChats = useMemo(() => chats.filter((c) => c.owner_id === user?.id), [chats, user]);
     const borrowerChats = useMemo(() => chats.filter((c) => c.borrower_id === user?.id), [chats, user]);
     const adminDisputes = useMemo(() => chats.filter((c) => c.status === 'pending_review'), [chats]);
-    
-    // Si es admin, mostramos solo incidencias
+
     const isAdmin = user?.role === 'admin';
     const scopedChats = isAdmin ? adminDisputes : (activeTab === 'owner' ? ownerChats : borrowerChats);
-    const groupedChats = useMemo(() => classifyChats(scopedChats), [scopedChats]);
+    const sortedChats = useMemo(() => [...scopedChats].sort(sortByDateDesc), [scopedChats]);
 
     if (!user) return null;
 
@@ -382,10 +259,7 @@ export default function ChatsPage() {
             )}
 
             {!loading && !error && chats.length > 0 && (
-                <ChatSection
-                    groups={groupedChats}
-                    currentUserID={user.id}
-                />
+                <ChatList chats={sortedChats} currentUserID={user.id} />
             )}
         </div>
     );

--- a/frontend/src/pages/chats/ChatsPage.tsx
+++ b/frontend/src/pages/chats/ChatsPage.tsx
@@ -56,8 +56,11 @@ function ChatCard({ message, currentUserID }: { message: Message; currentUserID:
     return (
         <Link
             to={`/transactions/${message.transaction_id}/chat`}
-            className="flex items-center gap-4 rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+            className="relative flex items-center gap-4 rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
         >
+            {message.has_unread && (
+                <span className="absolute top-3 right-3 h-3 w-3 rounded-full bg-green-500 ring-2 ring-white" />
+            )}
             {message.listing_photo ? (
                 <img
                     src={message.listing_photo}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,7 @@ export interface Transaction {
     status: TransactionStatus;
     stripe_payment_intent_id?: string;
     payment_method_id?: string;
+    payment_method?: 'card' | 'points';
     total_charged_cents: number;
     start_date: string | null;
     end_date: string | null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -61,6 +61,7 @@ export interface Message {
     listing_photo?: string;
     borrower_id?: string;
     owner_id?: string;
+    has_unread?: boolean;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Summary

Closes #76

Three UX improvements to the chats experience:

- **Flat sorted list:** Chats are now displayed as a single flat list ordered by most recent message (desc), removing the previous status-based grouping sections. The owner/borrower tab filter and admin disputes view are preserved.
- **Unread message dot:** A green dot appears on chat cards that have messages from the other party that the current user has not read yet. The dot clears the next time the user opens that chat.
- **Nav badge:** The chats icon in the top navigation now shows a red badge with the unread chat count, matching the existing notifications badge. Refreshes every 30 seconds.

## Backend changes

- New `chat_reads` table tracks the last time each user read each chat (upserted on chat open). **Run the SQL below in Supabase before deploying:**
  ```sql
  CREATE TABLE IF NOT EXISTS chat_reads (
      user_id        UUID NOT NULL REFERENCES users(id)        ON DELETE CASCADE,
      transaction_id UUID NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
      last_read_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
      PRIMARY KEY (user_id, transaction_id)
  );
  ```
- `GET /chats` now returns `has_unread: bool` per chat, computed via a correlated subquery against `chat_reads`.
- `POST /transactions/:id/messages/read` — marks the chat as read for the authenticated user (204).
- `GET /chats/unread-count` — returns `{ "count": N }` for the nav badge poll.

## Frontend changes

- `Message` type extended with `has_unread?: boolean`.
- `messagesApi` extended with `markAsRead()` and `getUnreadCount()`.
- `ChatsPage.tsx`: replaced `classifyChats` grouping logic with a flat `.sort()` by `created_at` desc; green dot added to `ChatCard`.
- `ChatDetailPage.tsx`: calls `markAsRead` on mount.
- `Layout.tsx`: polls `getUnreadCount` on mount and every 30 s; renders badge on chats icon.

## Test plan

- [ ] Run `CREATE TABLE chat_reads` SQL in Supabase.
- [ ] `go test ./backend/internal/messages/...` passes.
- [ ] `npx tsc --noEmit` in `frontend/` passes.
- [ ] Navigate to `/chats` — list is ordered by most recent message, no group headers.
- [ ] Send a message from account B to account A — green dot appears on that chat card in A's list.
- [ ] Open the chat as A — green dot is gone on next visit to `/chats`.
- [ ] Nav badge on chats icon shows count and clears within 30 s of reading messages.
