### PR TITLE
fix(wallet): align points history days calculation with service.Return logic

### DIFF
--- a/backend/internal/wallet/postgres_repository.go
+++ b/backend/internal/wallet/postgres_repository.go
@@ -111,7 +111,7 @@ func (r *postgresRepository) GetPointsHistory(ctx context.Context, userID string
             SELECT t.id as transaction_id, l.title as listing_title, t.return_at as completed_at,
                    FLOOR(
                      (t.total_charged_cents - 200) *
-                     (GREATEST(1, LEAST(7, (t.return_at::date - t.handover_at::date))) + 4)
+                     (GREATEST(1, LEAST(7, (GREATEST(t.end_date::date, t.return_at::date) - GREATEST(t.start_date::date, t.handover_at::date)))) + 4)
                      / 100.0
                    ) AS points_earned
             FROM transactions t


### PR DESCRIPTION
## Summary

- Fixes the discrepancy between the points credited to the lender's wallet and the points shown in the transaction history.
- The `GetPointsHistory` query was using `t.return_at - t.handover_at` (actual dates), while `service.Return` calculates points using effective dates (`max(end_date, now) - max(start_date, handover_at)`). On early returns this caused the history to display fewer points than were actually credited.
- Updated the SQL expression to mirror the service logic exactly, using `GREATEST(end_date, return_at) - GREATEST(start_date, handover_at)`.

Closes #84

## Test plan

- [ ] Run `go test ./internal/wallet/... ./internal/transactions/...` — all pass.
- [ ] Simulate an early return (return before scheduled end date) and confirm the history now shows the same amount as the wallet balance.
- [ ] Verify a normal/late return still produces the correct points (no regression).
